### PR TITLE
Correct values of Nano 33 BLE power save pin macros

### DIFF
--- a/variants/ARDUINO_NANO33BLE/pins_arduino.h
+++ b/variants/ARDUINO_NANO33BLE/pins_arduino.h
@@ -118,8 +118,8 @@ static const uint8_t SCK  = PIN_SPI_SCK;
 #define PIN_WIRE_SDA1       (30u)
 #define PIN_WIRE_SCL1       (31u)
 
-#define PIN_ENABLE_SENSORS_3V3     (32u)
-#define PIN_ENABLE_I2C_PULLUP      (33u)
+#define PIN_ENABLE_I2C_PULLUP      (32u)
+#define PIN_ENABLE_SENSORS_3V3     (33u)
 
 #define PIN_INT_APDS (26u)
 


### PR DESCRIPTION
The values of the `PIN_ENABLE_I2C_PULLUP` and `PIN_ENABLE_SENSORS_3V3` macros were swapped with each other.

https://github.com/arduino/ArduinoCore-mbed/blob/f368f7dad1b4221dca55eaca3f8293fd65ab8694/variants/ARDUINO_NANO33BLE/pins_arduino.h#L121-L122

https://github.com/arduino/ArduinoCore-mbed/blob/f368f7dad1b4221dca55eaca3f8293fd65ab8694/variants/ARDUINO_NANO33BLE/variant.cpp#L124-L125

![Clipboard01](https://user-images.githubusercontent.com/8572152/86822030-f12dba80-c03f-11ea-8352-8092f3e5e871.png)


