### PR TITLE
Fix Wifi AP issues

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -77,8 +77,14 @@ void arduino::WiFiClass::ensureDefaultAPNetworkConfiguration() {
 }
 
 void arduino::WiFiClass::end() {
+    disconnect();
+}
+
+int arduino::WiFiClass::disconnect() {
     if (softap != NULL) {
-        ((WhdSoftAPInterface*)softap)->stop();
+        return static_cast<WhdSoftAPInterface*>(softap)->stop();        
+    } else {
+        return wifi_if->disconnect();
     }
 }
 

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -25,7 +25,9 @@ int arduino::WiFiClass::begin(char* ssid, const char *passphrase) {
     }
 
     if (wifi_if == NULL) {
-       wifi_if = (WiFiInterface*)cb();
+        //Q: What is the callback for?
+        cb();
+        if(wifi_if == NULL) return WL_CONNECT_FAILED;
     }
 
     // too long? break it off

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -24,10 +24,10 @@ int arduino::WiFiClass::begin(char* ssid, const char *passphrase) {
         return WL_CONNECT_FAILED;
     }
 
-    if (wifi_if == NULL) {
+    if (wifi_if == nullptr) {
         //Q: What is the callback for?
-        cb();
-        if(wifi_if == NULL) return WL_CONNECT_FAILED;
+        _initializerCallback();
+        if(wifi_if == nullptr) return WL_CONNECT_FAILED;
     }
 
     // too long? break it off
@@ -50,18 +50,18 @@ int arduino::WiFiClass::begin(char* ssid, const char *passphrase) {
 int arduino::WiFiClass::beginAP(const char* ssid, const char *passphrase, uint8_t channel) {
 
 #if defined(ARDUINO_PORTENTA_H7_M7) || defined(ARDUINO_PORTENTA_H7_M4)
-    softap = WhdSoftAPInterface::get_default_instance();
+    _softAP = WhdSoftAPInterface::get_default_instance();
 #endif
 
-    if (softap == NULL) {
+    if (_softAP == NULL) {
         return WL_CONNECT_FAILED;
     }
 
     ensureDefaultAPNetworkConfiguration();
 
     //Set ap ssid, password and channel    
-    ((WhdSoftAPInterface*)softap)->set_network(_ip, _netmask, _gateway);
-    nsapi_error_t ret = ((WhdSoftAPInterface*)softap)->start(ssid, passphrase, NSAPI_SECURITY_WPA2, channel, true /* dhcp server */, NULL, true /* cohexistance */);
+    static_cast<WhdSoftAPInterface*>(_softAP)->set_network(_ip, _netmask, _gateway);
+    nsapi_error_t ret = static_cast<WhdSoftAPInterface*>(_softAP)->start(ssid, passphrase, NSAPI_SECURITY_WPA2, channel, true /* dhcp server */, NULL, true /* cohexistance */);
 
     return ret == NSAPI_ERROR_OK ? WL_AP_LISTENING : WL_CONNECT_FAILED;
 }
@@ -83,8 +83,8 @@ void arduino::WiFiClass::end() {
 }
 
 int arduino::WiFiClass::disconnect() {
-    if (softap != NULL) {
-        return static_cast<WhdSoftAPInterface*>(softap)->stop();        
+    if (_softAP != nullptr) {
+        return static_cast<WhdSoftAPInterface*>(_softAP)->stop();        
     } else {
         return wifi_if->disconnect();
     }
@@ -171,7 +171,7 @@ static uint8_t sec2enum(nsapi_security_t sec)
 
 int8_t arduino::WiFiClass::scanNetworks() {
     uint8_t count = 10;
-    if (ap_list == NULL) {
+    if (ap_list == nullptr) {
         ap_list = new WiFiAccessPoint[count];
     }
     return wifi_if->scan(ap_list, count);
@@ -243,8 +243,8 @@ arduino::IPAddress arduino::WiFiClass::gatewayIP() {
 }
 
 NetworkInterface *arduino::WiFiClass::getNetwork() {
-    if (softap != NULL) {
-        return softap;
+    if (_softAP != nullptr) {
+        return _softAP;
     } else {
         return wifi_if;
     }

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -48,11 +48,8 @@ int arduino::WiFiClass::beginAP(const char* ssid, const char *passphrase, uint8_
         return WL_CONNECT_FAILED;
     }
 
-    //Set ap ssid, password and channel
-    SocketAddress ip("192.168.3.1");
-    SocketAddress gw("192.168.3.1");
-    SocketAddress netmask("255.255.255.0");
-    ((WhdSoftAPInterface*)softap)->set_network(ip, gw, netmask);
+    //Set ap ssid, password and channel    
+    ((WhdSoftAPInterface*)softap)->set_network(_ip, _netmask, _gateway);
     nsapi_error_t ret = ((WhdSoftAPInterface*)softap)->start(ssid, passphrase, NSAPI_SECURITY_WPA2, channel, true /* dhcp server */, NULL, true /* cohexistance */);
 
     return ret == NSAPI_ERROR_OK ? WL_AP_LISTENING : WL_CONNECT_FAILED;

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -48,6 +48,8 @@ int arduino::WiFiClass::beginAP(const char* ssid, const char *passphrase, uint8_
         return WL_CONNECT_FAILED;
     }
 
+    ensureDefaultAPNetworkConfiguration();
+
     //Set ap ssid, password and channel    
     ((WhdSoftAPInterface*)softap)->set_network(_ip, _netmask, _gateway);
     nsapi_error_t ret = ((WhdSoftAPInterface*)softap)->start(ssid, passphrase, NSAPI_SECURITY_WPA2, channel, true /* dhcp server */, NULL, true /* cohexistance */);
@@ -55,10 +57,31 @@ int arduino::WiFiClass::beginAP(const char* ssid, const char *passphrase, uint8_
     return ret == NSAPI_ERROR_OK ? WL_AP_LISTENING : WL_CONNECT_FAILED;
 }
 
+void arduino::WiFiClass::ensureDefaultAPNetworkConfiguration() {
+    if(_ip == nullptr){
+        _ip = SocketAddress("192.168.3.1");
+    }
+    if(_gateway == nullptr){
+        _gateway = _ip;
+    }
+    if(_netmask == nullptr){
+        _netmask = SocketAddress("255.255.255.0");
+    }
+}
+
 void arduino::WiFiClass::end() {
     if (softap != NULL) {
         ((WhdSoftAPInterface*)softap)->stop();
     }
+}
+
+void arduino::WiFiClass::config(arduino::IPAddress local_ip){    
+    nsapi_addr_t convertedIP = {NSAPI_IPv4, {local_ip[0], local_ip[1], local_ip[2], local_ip[3]}};    
+    _ip = SocketAddress(convertedIP);    
+}
+
+void arduino::WiFiClass::config(const char *local_ip){
+    _ip = SocketAddress(local_ip);    
 }
 
 char* arduino::WiFiClass::SSID() {

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -219,17 +219,25 @@ uint8_t* arduino::WiFiClass::macAddress(uint8_t* mac) {
     return mac;
 }
 
-arduino::IPAddress arduino::WiFiClass::localIP() {
-    arduino::IPAddress addr;
-
+arduino::IPAddress arduino::WiFiClass::localIP() {    
     SocketAddress ip;
-    if (softap != NULL) {
-        softap->get_ip_address(&ip);
-    } else {
-        wifi_if->get_ip_address(&ip);
-    }
-    addr.fromString(ip.get_ip_address()); // @todo: the IP we get from Mbed is correct, but is parsed incorrectly by Arduino
-    return addr;
+    NetworkInterface *interface = getNetwork();
+    interface->get_ip_address(&ip);
+    return ipAddressFromSocketAddress(ip);    
+}
+
+arduino::IPAddress arduino::WiFiClass::subnetMask() {    
+    SocketAddress ip;
+    NetworkInterface *interface = getNetwork();
+    interface->get_netmask(&ip);
+    return ipAddressFromSocketAddress(ip);    
+}
+
+arduino::IPAddress arduino::WiFiClass::gatewayIP() {    
+    SocketAddress ip;
+    NetworkInterface *interface = getNetwork();
+    interface->get_gateway(&ip);
+    return ipAddressFromSocketAddress(ip);    
 }
 
 NetworkInterface *arduino::WiFiClass::getNetwork() {

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -84,6 +84,36 @@ void arduino::WiFiClass::config(const char *local_ip){
     _ip = SocketAddress(local_ip);    
 }
 
+void arduino::WiFiClass::config(IPAddress local_ip, IPAddress dns_server){
+    config(local_ip);
+    nsapi_addr_t convertedDNSServer = {NSAPI_IPv4, {dns_server[0], dns_server[1], dns_server[2], dns_server[3]}};    
+    _dnsServer1 = SocketAddress(convertedDNSServer);
+}
+
+void arduino::WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway){
+    config(local_ip, dns_server);
+    nsapi_addr_t convertedGatewayIP = {NSAPI_IPv4, {gateway[0], gateway[1], gateway[2], gateway[3]}};    
+    _gateway = SocketAddress(convertedGatewayIP);
+}
+
+void arduino::WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet){    
+    config(local_ip, dns_server, gateway);
+    nsapi_addr_t convertedSubnetMask = {NSAPI_IPv4, {subnet[0], subnet[1], subnet[2], subnet[3]}};    
+    _netmask = SocketAddress(convertedSubnetMask);
+}
+
+void arduino::WiFiClass::setDNS(IPAddress dns_server1){
+    nsapi_addr_t convertedDNSServer = {NSAPI_IPv4, {dns_server1[0], dns_server1[1], dns_server1[2], dns_server1[3]}};    
+    _dnsServer1 = SocketAddress(convertedDNSServer);
+}
+
+void arduino::WiFiClass::setDNS(IPAddress dns_server1, IPAddress dns_server2){
+    nsapi_addr_t convertedDNSServer1 = {NSAPI_IPv4, {dns_server1[0], dns_server1[1], dns_server1[2], dns_server1[3]}};    
+    _dnsServer1 = SocketAddress(convertedDNSServer1);
+    nsapi_addr_t convertedDNSServer2 = {NSAPI_IPv4, {dns_server2[0], dns_server2[1], dns_server2[2], dns_server2[3]}};    
+    _dnsServer2 = SocketAddress(convertedDNSServer2);    
+}
+
 char* arduino::WiFiClass::SSID() {
     return _ssid;
 }

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -10,6 +10,11 @@ bool arduino::WiFiClass::isVisible(char* ssid) {
     return false;
 }
 
+arduino::IPAddress arduino::WiFiClass::ipAddressFromSocketAddress(SocketAddress socketAddress) {
+    nsapi_addr_t address = socketAddress.get_addr();
+    return IPAddress(address.bytes[0], address.bytes[1], address.bytes[2], address.bytes[3]);    
+}
+
 int arduino::WiFiClass::begin(char* ssid, const char *passphrase) {
     if (_ssid) free(_ssid);
 

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -35,12 +35,14 @@ int arduino::WiFiClass::begin(char* ssid, const char *passphrase) {
     scanNetworks();
     // use scan result to populate security field
     if (!isVisible(ssid)) {
-        return WL_CONNECT_FAILED;
+        _currentNetworkStatus = WL_CONNECT_FAILED;
+        return _currentNetworkStatus;
     }
 
     nsapi_error_t ret = wifi_if->connect(ssid, passphrase, ap_list[connected_ap].get_security());
 
-    return ret == NSAPI_ERROR_OK ? WL_CONNECTED : WL_CONNECT_FAILED;
+    _currentNetworkStatus = ret == NSAPI_ERROR_OK ? WL_CONNECTED : WL_CONNECT_FAILED;
+    return _currentNetworkStatus;
 }
 
 int arduino::WiFiClass::beginAP(const char* ssid, const char *passphrase, uint8_t channel) {
@@ -183,9 +185,8 @@ int32_t arduino::WiFiClass::RSSI() {
     return wifi_if->get_rssi();
 }
 
-uint8_t arduino::WiFiClass::status() {
-    // @todo: fix
-    return WL_CONNECTED;
+uint8_t arduino::WiFiClass::status() {    
+    return _currentNetworkStatus;
 }
 
 uint8_t arduino::WiFiClass::encryptionType() {

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -59,13 +59,13 @@ int arduino::WiFiClass::beginAP(const char* ssid, const char *passphrase, uint8_
 
 void arduino::WiFiClass::ensureDefaultAPNetworkConfiguration() {
     if(_ip == nullptr){
-        _ip = SocketAddress("192.168.3.1");
+        _ip = SocketAddress(DEFAULT_IP_ADDRESS);
     }
     if(_gateway == nullptr){
         _gateway = _ip;
     }
     if(_netmask == nullptr){
-        _netmask = SocketAddress("255.255.255.0");
+        _netmask = SocketAddress(DEFAULT_NETMASK);
     }
 }
 

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -208,7 +208,7 @@ uint8_t* arduino::WiFiClass::BSSID(unsigned char* bssid) {
 }
 
 uint8_t* arduino::WiFiClass::macAddress(uint8_t* mac) {
-    const char *mac_str = wifi_if->get_mac_address();
+    const char *mac_str = getNetwork()->get_mac_address();
     for( int b = 0; b < 6; b++ )
     {
         uint32_t tmp;

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -86,8 +86,7 @@ void arduino::WiFiClass::config(const char *local_ip){
 
 void arduino::WiFiClass::config(IPAddress local_ip, IPAddress dns_server){
     config(local_ip);
-    nsapi_addr_t convertedDNSServer = {NSAPI_IPv4, {dns_server[0], dns_server[1], dns_server[2], dns_server[3]}};    
-    _dnsServer1 = SocketAddress(convertedDNSServer);
+    setDNS(dns_server);    
 }
 
 void arduino::WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway){
@@ -108,8 +107,7 @@ void arduino::WiFiClass::setDNS(IPAddress dns_server1){
 }
 
 void arduino::WiFiClass::setDNS(IPAddress dns_server1, IPAddress dns_server2){
-    nsapi_addr_t convertedDNSServer1 = {NSAPI_IPv4, {dns_server1[0], dns_server1[1], dns_server1[2], dns_server1[3]}};    
-    _dnsServer1 = SocketAddress(convertedDNSServer1);
+    setDNS(dns_server1);
     nsapi_addr_t convertedDNSServer2 = {NSAPI_IPv4, {dns_server2[0], dns_server2[1], dns_server2[2], dns_server2[3]}};    
     _dnsServer2 = SocketAddress(convertedDNSServer2);    
 }

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -310,6 +310,7 @@ private:
     bool isVisible(char* ssid);
     arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
     char* _ssid;
+    wl_status_t _currentNetworkStatus = WL_IDLE_STATUS;
     WiFiInterface* wifi_if;
     voidPrtFuncPtr cb;
     WiFiAccessPoint* ap_list = NULL;

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -37,6 +37,9 @@ extern "C" {
 #include "WhdSoftAPInterface.h"
 #endif
 
+#define DEFAULT_IP_ADDRESS "192.168.3.1"
+#define DEFAULT_NETMASK "255.255.255.0"
+
 namespace arduino {
 
 typedef void* (*voidPrtFuncPtr)(void);

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -283,6 +283,10 @@ private:
 
     EMACInterface* softap;
 
+    SocketAddress _ip = SocketAddress("192.168.3.1");
+    SocketAddress _gateway = SocketAddress("192.168.3.1");
+    SocketAddress _netmask = SocketAddress("255.255.255.0");
+
     bool isVisible(char* ssid);
     char* _ssid;
     WiFiInterface* wifi_if;

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -294,6 +294,8 @@ private:
     SocketAddress _ip = nullptr;
     SocketAddress _gateway = nullptr;
     SocketAddress _netmask = nullptr;
+    SocketAddress _dnsServer1 = nullptr;
+    SocketAddress _dnsServer2 = nullptr;
 
     void ensureDefaultAPNetworkConfiguration();
     bool isVisible(char* ssid);

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -308,6 +308,7 @@ private:
 
     void ensureDefaultAPNetworkConfiguration();
     bool isVisible(char* ssid);
+    arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
     char* _ssid;
     WiFiInterface* wifi_if;
     voidPrtFuncPtr cb;

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -55,16 +55,13 @@ typedef void* (*voidPrtFuncPtr)(void);
 
 class WiFiClass
 {
-private:
-
-    static void init();
 public:
     static int16_t 	_state[MAX_SOCK_NUM];
     static uint16_t _server_port[MAX_SOCK_NUM];
 
     WiFiClass(WiFiInterface* _if) : wifi_if(_if) {};
 
-    WiFiClass(voidPrtFuncPtr _cb) : cb(_cb) {};
+    WiFiClass(voidPrtFuncPtr _cb) : _initializerCallback(_cb) {};
 
     /*
      * Get the first socket available
@@ -294,27 +291,26 @@ public:
     friend class WiFiClient;
     friend class WiFiServer;
 
-public:
     NetworkInterface *getNetwork();
 
 private:
 
-    EMACInterface* softap;
+    EMACInterface* _softAP = nullptr;
     SocketAddress _ip = nullptr;
     SocketAddress _gateway = nullptr;
     SocketAddress _netmask = nullptr;
     SocketAddress _dnsServer1 = nullptr;
     SocketAddress _dnsServer2 = nullptr;
+    char* _ssid = nullptr;
+    wl_status_t _currentNetworkStatus = WL_IDLE_STATUS;
+    WiFiInterface* wifi_if = nullptr;
+    voidPrtFuncPtr _initializerCallback;
+    WiFiAccessPoint* ap_list = nullptr;
+    uint8_t connected_ap;
 
     void ensureDefaultAPNetworkConfiguration();
     bool isVisible(char* ssid);
     arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
-    char* _ssid;
-    wl_status_t _currentNetworkStatus = WL_IDLE_STATUS;
-    WiFiInterface* wifi_if;
-    voidPrtFuncPtr cb;
-    WiFiAccessPoint* ap_list = NULL;
-    uint8_t connected_ap;
 };
 
 }

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -39,6 +39,7 @@ extern "C" {
 
 #define DEFAULT_IP_ADDRESS "192.168.3.1"
 #define DEFAULT_NETMASK "255.255.255.0"
+#define DEFAULT_AP_CHANNEL 6
 
 namespace arduino {
 
@@ -93,7 +94,7 @@ public:
      */
     int begin(char* ssid, const char *passphrase);
 
-    int beginAP(const char *ssid, const char* passphrase, uint8_t channel = 6);
+    int beginAP(const char *ssid, const char* passphrase, uint8_t channel = DEFAULT_AP_CHANNEL);
 
     /* Change Ip configuration settings disabling the dhcp client
         *

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -97,6 +97,12 @@ public:
         * param local_ip: 	Static ip configuration
         */
     void config(IPAddress local_ip);
+    
+    /* Change Ip configuration settings disabling the dhcp client
+        *
+        * param local_ip: 	Static ip configuration as string
+        */
+    void config(const char *local_ip);
 
     /* Change Ip configuration settings disabling the dhcp client
         *
@@ -282,11 +288,11 @@ public:
 private:
 
     EMACInterface* softap;
+    SocketAddress _ip = nullptr;
+    SocketAddress _gateway = nullptr;
+    SocketAddress _netmask = nullptr;
 
-    SocketAddress _ip = SocketAddress("192.168.3.1");
-    SocketAddress _gateway = SocketAddress("192.168.3.1");
-    SocketAddress _netmask = SocketAddress("255.255.255.0");
-
+    void ensureDefaultAPNetworkConfiguration();
     bool isVisible(char* ssid);
     char* _ssid;
     WiFiInterface* wifi_if;

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -37,9 +37,17 @@ extern "C" {
 #include "WhdSoftAPInterface.h"
 #endif
 
+#ifndef DEFAULT_IP_ADDRESS
 #define DEFAULT_IP_ADDRESS "192.168.3.1"
+#endif
+
+#ifndef DEFAULT_NETMASK
 #define DEFAULT_NETMASK "255.255.255.0"
+#endif
+
+#ifndef DEFAULT_AP_CHANNEL
 #define DEFAULT_AP_CHANNEL 6
+#endif
 
 namespace arduino {
 


### PR DESCRIPTION
Due to a bug in the wifi AP setup function  the netmask wasn't set correctly and some users couldn't connect to the Portenta. This PR fixes it and also makes the network parameters configurable.