### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,9 +1,25 @@
 name: Compile Examples
 
-on: [pull_request, push]
+on: 
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "cores/**"
+      - "libraries/**"
+      - "variants/**"
+      - "boards.txt"
+      - "platform.txt"
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "cores/**"
+      - "libraries/**"
+      - "variants/**"
+      - "boards.txt"
+      - "platform.txt"
 
 jobs:
-  compile-test:
+  compile-examples:
     runs-on: ubuntu-latest
 
     env:
@@ -14,22 +30,21 @@ jobs:
       fail-fast: false
 
       matrix:
-        board: [
-          {"fqbn": "arduino-beta:mbed:nano33ble"},
-          {"fqbn": "arduino-beta:mbed:envie_m4"},
-          {"fqbn": "arduino-beta:mbed:envie_m7"}
-        ]
+        board:
+          - fqbn: arduino-beta:mbed:nano33ble
+          - fqbn: arduino-beta:mbed:envie_m4
+          - fqbn: arduino-beta:mbed:envie_m7
 
         # compile only the examples compatible with each board
         include:
           - board:
-              fqbn: "arduino-beta:mbed:nano33ble"
+              fqbn: arduino-beta:mbed:nano33ble
             additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug"'
           - board:
-              fqbn: "arduino-beta:mbed:envie_m4"
+              fqbn: arduino-beta:mbed:envie_m4
             additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" '
           - board:
-              fqbn: "arduino-beta:mbed:envie_m7"
+              fqbn: arduino-beta:mbed:envie_m7
             additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_Audio" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST"'
 
     steps:

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -77,3 +77,11 @@ jobs:
               name: "arduino-beta:mbed"
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
           verbose: 'false'
+          enable-size-deltas-report: true
+
+      - name: Save memory usage change report as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+          name: size-deltas-reports
+          path: size-deltas-reports

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,13 +25,13 @@ jobs:
           # normal boards
           - board:
               fqbn: "arduino-beta:mbed:nano33ble"
-            additional-sketch-paths: '"libraries/PDM"'
+            additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug"'
           - board:
               fqbn: "arduino-beta:mbed:envie_m4"
-            additional-sketch-paths: '"libraries/doom"'
+            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" '
           - board:
               fqbn: "arduino-beta:mbed:envie_m7"
-            additional-sketch-paths: '"libraries/doom"'
+            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_Audio" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST"'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,77 @@
+name: Compile Examples
+
+on: [pull_request, push]
+
+jobs:
+  compile-test:
+    runs-on: ubuntu-latest
+
+    env:
+      # sketch paths to compile (recursive) for all boards
+      UNIVERSAL_SKETCH_PATHS: '"libraries/Scheduler"'
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board: [
+          {"fqbn": "arduino-beta:mbed:nano33ble"},
+          {"fqbn": "arduino-beta:mbed:envie_m4"},
+          {"fqbn": "arduino-beta:mbed:envie_m7"}
+        ]
+
+        # make board type-specific customizations to the matrix jobs
+        include:
+          # normal boards
+          - board:
+              fqbn: "arduino-beta:mbed:nano33ble"
+            additional-sketch-paths: '"libraries/PDM"'
+          - board:
+              fqbn: "arduino-beta:mbed:envie_m4"
+            additional-sketch-paths: '"libraries/doom"'
+          - board:
+              fqbn: "arduino-beta:mbed:envie_m7"
+            additional-sketch-paths: '"libraries/doom"'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # The source files are in a subfolder of the ArduinoCore-API repository, so it's not possible to clone it directly to the final destination in the core
+      #- name: Checkout ArduinoCore-API
+      #  uses: actions/checkout@v2
+        #with:
+        #  repository: arduino/ArduinoCore-API
+        #  path: extras/ArduinoCore-API
+
+      #- name: Install ArduinoCore-API
+      #  run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"   
+
+      #- name: Checkout Adafruit WiFiNINA
+      #  uses: actions/checkout@v2
+      #  with:
+      #    repository: adafruit/WiFiNINA
+      #    path: adafruit/WiFiNINA
+
+      - name: Compile examples
+        uses: arduino/actions/libraries/compile-examples@master
+        with:
+          fqbn: ${{ matrix.board.fqbn }}
+          # libraries: |
+            # ${{ env.UNIVERSAL_LIBRARIES }}
+          platforms: |
+            # Use Board Manager to install the latest release of Arduino mbed Boards to get the toolchain
+            - name: "arduino-beta:mbed"
+            # Overwrite the Board Manager installation with the local platform
+            # - source-path: "./"
+            #   name: "arduino-beta:mbed"
+          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
+          # enable-size-deltas-report: 'true'
+          verbose: 'false'
+
+      # - name: Save memory usage change report as artifact
+      #   if: github.event_name == 'pull_request'
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     name: 'size-deltas-reports'
+      #     path: 'size-deltas-reports'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -61,12 +61,4 @@ jobs:
             - source-path: "./"
               name: "arduino-beta:mbed"
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
-          enable-size-deltas-report: 'true'
           verbose: 'false'
-
-      - name: Save memory usage change report as artifact
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v1
-        with:
-          name: 'size-deltas-reports'
-          path: 'size-deltas-reports'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # sketch paths to compile (recursive) for all boards
+      # sketch paths to compile (recursive) compatible with all boards
       UNIVERSAL_SKETCH_PATHS: '"libraries/Scheduler"'
 
     strategy:
@@ -20,9 +20,8 @@ jobs:
           {"fqbn": "arduino-beta:mbed:envie_m7"}
         ]
 
-        # make board type-specific customizations to the matrix jobs
+        # compile only the examples compatible with each board
         include:
-          # normal boards
           - board:
               fqbn: "arduino-beta:mbed:nano33ble"
             additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug"'
@@ -38,40 +37,36 @@ jobs:
         uses: actions/checkout@v2
 
       # The source files are in a subfolder of the ArduinoCore-API repository, so it's not possible to clone it directly to the final destination in the core
-      #- name: Checkout ArduinoCore-API
-      #  uses: actions/checkout@v2
-        #with:
-        #  repository: arduino/ArduinoCore-API
-        #  path: extras/ArduinoCore-API
+      - name: Checkout ArduinoCore-API
+        uses: actions/checkout@v2
+        with:
+          repository: arduino/ArduinoCore-API
+          ref: namespace_arduino
+          path: ArduinoCore-API
 
-      #- name: Install ArduinoCore-API
-      #  run: mv "$GITHUB_WORKSPACE/extras/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"   
+      - name: Remove old symlink to api
+        run: rm "$GITHUB_WORKSPACE/cores/arduino/api"
 
-      #- name: Checkout Adafruit WiFiNINA
-      #  uses: actions/checkout@v2
-      #  with:
-      #    repository: adafruit/WiFiNINA
-      #    path: adafruit/WiFiNINA
+      - name: Install ArduinoCore-API
+        run: mv "$GITHUB_WORKSPACE/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"   
 
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:
           fqbn: ${{ matrix.board.fqbn }}
-          # libraries: |
-            # ${{ env.UNIVERSAL_LIBRARIES }}
           platforms: |
             # Use Board Manager to install the latest release of Arduino mbed Boards to get the toolchain
             - name: "arduino-beta:mbed"
             # Overwrite the Board Manager installation with the local platform
-            # - source-path: "./"
-            #   name: "arduino-beta:mbed"
+            - source-path: "./"
+              name: "arduino-beta:mbed"
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
-          # enable-size-deltas-report: 'true'
+          enable-size-deltas-report: 'true'
           verbose: 'false'
 
-      # - name: Save memory usage change report as artifact
-      #   if: github.event_name == 'pull_request'
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: 'size-deltas-reports'
-      #     path: 'size-deltas-reports'
+      - name: Save memory usage change report as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v1
+        with:
+          name: 'size-deltas-reports'
+          path: 'size-deltas-reports'

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,11 @@
+on:
+  schedule:
+    - cron:  '*/5 * * * *'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/actions/libraries/report-size-deltas@master


### PR DESCRIPTION
I've added a github CI workflow useful to compile the examples from the libraries that come with the core.
I did some try and error investigation regarding the libraries in the core and the compatibility with nano ble or portenta boards: some libraries are compatible with both the portenta platform and the nano33ble platform, some others are not. Thus the compile process is done only for the compatible examples.