### PR TITLE
variants/../pins_arduino.h modernised defines about LED's and Digital pins

### DIFF
--- a/variants/ARDUINO_NANO33BLE/pins_arduino.h
+++ b/variants/ARDUINO_NANO33BLE/pins_arduino.h
@@ -61,6 +61,24 @@ extern "C" unsigned int PINCOUNT_fn();
 #define LED_GREEN   LEDG
 #define LED_BLUE    LEDB
 
+// Digital pins
+// -----------
+#define D0   0
+#define D1   1
+#define D2   2
+#define D3   3
+#define D4   4
+#define D5   5
+#define D6   6
+#define D7   7
+#define D8   8
+#define D9   9
+#define D10  10
+#define D11  11
+#define D12  12
+#define D13  13
+
+
 // Analog pins
 // -----------
 #define PIN_A0 (14u)
@@ -80,23 +98,6 @@ static const uint8_t A5  = PIN_A5;
 static const uint8_t A6  = PIN_A6;
 static const uint8_t A7  = PIN_A7;
 #define ADC_RESOLUTION 12
-
-// Digital pins
-// -----------
-#define D0   0
-#define D1   1
-#define D2   2
-#define D3   3
-#define D4   4
-#define D5   5
-#define D6   6
-#define D7   7
-#define D8   8
-#define D9   9
-#define D10  10
-#define D11  11
-#define D12  12
-#define D13  13
 
 /*
  * Serial interfaces

--- a/variants/ARDUINO_NANO33BLE/pins_arduino.h
+++ b/variants/ARDUINO_NANO33BLE/pins_arduino.h
@@ -55,6 +55,11 @@ extern "C" unsigned int PINCOUNT_fn();
 #define LEDG        (23u)
 #define LEDB        (24u)
 #define LED_PWR     (25u)
+#define LED_ONBOARD_HIGH 0   // grounded to turn LED on
+#define LED_ONBOARD_LOW  1   // not grounded to turn LED off
+#define LED_RED     LEDR
+#define LED_GREEN   LEDG
+#define LED_BLUE    LEDB
 
 // Analog pins
 // -----------

--- a/variants/PORTENTA_H7_M4/pins_arduino.h
+++ b/variants/PORTENTA_H7_M4/pins_arduino.h
@@ -20,6 +20,36 @@ extern "C" bool isBetaBoard();
 #define LEDR        (22u)
 #define LEDG        (23u)
 #define LEDB        (24u)
+#define LED_ONBOARD_HIGH 0   // grounded to turn LED on
+#define LED_ONBOARD_LOW  1   // not grounded to turn LED off
+#define LED_RED     LEDR
+#define LED_GREEN   LEDG
+#define LED_BLUE    LEDB
+
+// Digital pins
+// -----------
+#define D0   0
+#define D1   1
+#define D2   2
+#define D3   3
+#define D4   4
+#define D5   5
+#define D6   6
+#define D7   7
+#define D8   8
+#define D9   9
+#define D10  10
+#define D11  11
+#define D12  12
+#define D13  13
+#define D14  14
+#define D15  15
+#define D16  16
+#define D17  17
+#define D18  18
+#define D19  19
+#define D20  20
+#define D21  21
 
 // Analog pins
 // -----------

--- a/variants/PORTENTA_H7_M7/pins_arduino.h
+++ b/variants/PORTENTA_H7_M7/pins_arduino.h
@@ -20,6 +20,36 @@ extern "C" bool isBetaBoard();
 #define LEDR        (22u)
 #define LEDG        (23u)
 #define LEDB        (24u)
+#define LED_ONBOARD_HIGH 0   // grounded to turn LED on
+#define LED_ONBOARD_LOW  1   // not grounded to turn LED off
+#define LED_RED     LEDR
+#define LED_GREEN   LEDG
+#define LED_BLUE    LEDB
+
+// Digital pins
+// -----------
+#define D0   0
+#define D1   1
+#define D2   2
+#define D3   3
+#define D4   4
+#define D5   5
+#define D6   6
+#define D7   7
+#define D8   8
+#define D9   9
+#define D10  10
+#define D11  11
+#define D12  12
+#define D13  13
+#define D14  14
+#define D15  15
+#define D16  16
+#define D17  17
+#define D18  18
+#define D19  19
+#define D20  20
+#define D21  21
 
 // Analog pins
 // -----------


### PR DESCRIPTION
1. To align the Portenta with the Nano 33 BLE I have added digital pins to match the markings on the boards. I also moved the Nano 33 BLE Digital pin define to be just after the LED defines, for simplicity. For the NANO 33 BLE there are 13 digital pins. For the M7 and M4 there are 21 digital pins. (Could actually be much higher but these are the only pins available without the high density connector.)

```
// Digital pins
// -----------
#define D0   0
#define D1   1
etc, etc
```

2. To modernise the on-board LED I have included more modern naming defines

```
#define LED_RED     LEDR
#define LED_GREEN   LEDG
#define LED_BLUE    LEDB
```


3. To simplify the confusion of the 3V3 attached on-board LED's I have included an obvious define for setting the on-board LED's HIGH and LOW that does not interfere with other LED's set to HIGH and LOW. 

```
#define LED_ONBOARD_HIGH 0   // grounded to turn LED on
#define LED_ONBOARD_LOW  1   // not grounded to turn LED off
```


If this change is welcomed I would see if the other Nano 33 IOT and BLE github repositories would accept the same defines but relevant to those boards.