### PR TITLE
Add easy to remember alias for LL_RCC_ForceCM4Boot

### DIFF
--- a/variants/PORTENTA_H7_M7/pins_arduino.h
+++ b/variants/PORTENTA_H7_M7/pins_arduino.h
@@ -8,6 +8,13 @@
 extern "C" unsigned int PINCOUNT_fn();
 extern "C" bool isBetaBoard();
 #endif
+
+// Booting
+// ----
+#define bootM4() LL_RCC_ForceCM4Boot() // Provide a memorable alias
+
+// Pin count
+// ----
 #define PINS_COUNT           (PINCOUNT_fn())
 #define NUM_DIGITAL_PINS     (22u)
 #define NUM_ANALOG_INPUTS    (7u)


### PR DESCRIPTION
I've added an alias for force-booting the M4 which is less cryptic than LL_RCC_ForceCM4Boot.
Not sure if Arduino.h is the best place to put it. I'm open to feedback. @facchinm 