### PR TITLE
Add missing implementations to WiFi and WiFiClient

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -15,7 +15,7 @@ arduino::IPAddress arduino::WiFiClass::ipAddressFromSocketAddress(SocketAddress 
     return IPAddress(address.bytes[0], address.bytes[1], address.bytes[2], address.bytes[3]);    
 }
 
-SocketAddress arduino::WiFiClass::socketAddressFromIpAddress(arduino::IPAddress ipAddress, uint16_t port) {
+SocketAddress arduino::WiFiClass::socketAddressFromIpAddress(arduino::IPAddress ip, uint16_t port) {
     nsapi_addr_t convertedIP = {NSAPI_IPv4, {ip[0], ip[1], ip[2], ip[3]}};    
     return SocketAddress(convertedIP, port);
 }

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -202,6 +202,17 @@ uint8_t arduino::WiFiClass::status() {
     return _currentNetworkStatus;
 }
 
+int arduino::WiFiClass::hostByName(const char* aHostname, IPAddress& aResult){
+    SocketAddress socketAddress = SocketAddress();
+    nsapi_error_t returnCode = getNetwork()->gethostbyname(aHostname, &socketAddress);
+    nsapi_addr_t address = socketAddress.get_addr();
+    aResult[0] = address.bytes[0];
+    aResult[1] = address.bytes[1];
+    aResult[2] = address.bytes[2];
+    aResult[3] = address.bytes[3];    
+    return returnCode == NSAPI_ERROR_OK ? 1 : 0;
+}
+
 uint8_t arduino::WiFiClass::encryptionType() {
     return sec2enum(ap_list[connected_ap].get_security());
 }

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -15,6 +15,11 @@ arduino::IPAddress arduino::WiFiClass::ipAddressFromSocketAddress(SocketAddress 
     return IPAddress(address.bytes[0], address.bytes[1], address.bytes[2], address.bytes[3]);    
 }
 
+SocketAddress arduino::WiFiClass::socketAddressFromIpAddress(arduino::IPAddress ipAddress, uint16_t port) {
+    nsapi_addr_t convertedIP = {NSAPI_IPv4, {ip[0], ip[1], ip[2], ip[3]}};    
+    return SocketAddress(convertedIP, port);
+}
+
 int arduino::WiFiClass::begin(const char* ssid, const char *passphrase) {
     if (_ssid) free(_ssid);
 

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -290,6 +290,7 @@ public:
 
     friend class WiFiClient;
     friend class WiFiServer;
+    friend class WiFiUDP;
 
     NetworkInterface *getNetwork();
 

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -311,6 +311,7 @@ private:
     void ensureDefaultAPNetworkConfiguration();
     bool isVisible(const char* ssid);
     arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
+    SocketAddress socketAddressFromIpAddress(arduino::IPAddress ipAddress, uint16_t port);
 };
 
 }

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -311,7 +311,7 @@ private:
     void ensureDefaultAPNetworkConfiguration();
     bool isVisible(const char* ssid);
     arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
-    SocketAddress socketAddressFromIpAddress(arduino::IPAddress ipAddress, uint16_t port);
+    SocketAddress socketAddressFromIpAddress(arduino::IPAddress ip, uint16_t port);
 };
 
 }

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -24,26 +24,27 @@ void arduino::WiFiClient::getStatus() {
     }
 }
 
-
-int arduino::WiFiClient::connect(IPAddress ip, uint16_t port) {
-}
-
-int arduino::WiFiClient::connect(const char *host, uint16_t port) {
+int arduino::WiFiClient::connect(SocketAddress socketAddress) {
 	if (sock == NULL) {
-		sock = new TCPSocket();
-		((TCPSocket*)sock)->open(WiFi.getNetwork());
+		sock = new TCPSocket();		
+		static_cast<TCPSocket*>(sock)->open(WiFi.getNetwork());
 	}
 	//sock->sigio(mbed::callback(this, &WiFiClient::getStatus));
 	//sock->set_blocking(false);
-	sock->set_timeout(1000);
-	SocketAddress addr(host, port);
-	WiFi.getNetwork()->gethostbyname(host, &addr);
-	int ret = ((TCPSocket*)sock)->connect(addr);
-	if (ret == 0) {
-		return 1;
-	} else {
-		return 0;
-	}
+	sock->set_timeout(1000);		
+	nsapi_error_t returnCode = static_cast<TCPSocket*>(sock)->connect(socketAddress);
+	return returnCode == NSAPI_ERROR_OK ? 1 : 0;
+}
+
+int arduino::WiFiClient::connect(IPAddress ip, uint16_t port) {	
+	return connect(WiFi.socketAddressFromIpAddress(ip, port));
+}
+
+int arduino::WiFiClient::connect(const char *host, uint16_t port) {
+	SocketAddress socketAddress = SocketAddress();
+	socketAddress.set_port(port);
+	WiFi.getNetwork()->gethostbyname(host, &socketAddress);
+	return connect(socketAddress);
 }
 
 int arduino::WiFiClient::connectSSL(IPAddress ip, uint16_t port) {

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -6,6 +6,10 @@ extern WiFiClass WiFi;
 #define WIFI_TCP_BUFFER_SIZE        1508
 #endif
 
+#ifndef SOCKET_TIMEOUT
+#define SOCKET_TIMEOUT 1000
+#endif
+
 arduino::WiFiClient::WiFiClient() {
 }
 
@@ -31,7 +35,7 @@ int arduino::WiFiClient::connect(SocketAddress socketAddress) {
 	}
 	//sock->sigio(mbed::callback(this, &WiFiClient::getStatus));
 	//sock->set_blocking(false);
-	sock->set_timeout(1000);		
+	sock->set_timeout(SOCKET_TIMEOUT);		
 	nsapi_error_t returnCode = static_cast<TCPSocket*>(sock)->connect(socketAddress);
 	return returnCode == NSAPI_ERROR_OK ? 1 : 0;
 }
@@ -47,26 +51,28 @@ int arduino::WiFiClient::connect(const char *host, uint16_t port) {
 	return connect(socketAddress);
 }
 
-int arduino::WiFiClient::connectSSL(IPAddress ip, uint16_t port) {
-}
-
-int arduino::WiFiClient::connectSSL(const char *host, uint16_t port) {
+int arduino::WiFiClient::connectSSL(SocketAddress socketAddress){
 	if (sock == NULL) {
 		sock = new TLSSocket();
-		((TLSSocket*)sock)->open(WiFi.getNetwork());
+		static_cast<TLSSocket*>(sock)->open(WiFi.getNetwork());
 	}
 	if (beforeConnect) {
 		beforeConnect();
 	}
-	sock->set_timeout(1000);
-	SocketAddress addr(host, port);
-	WiFi.getNetwork()->gethostbyname(host, &addr);
-	int ret = ((TLSSocket*)sock)->connect(addr);
-	if (ret == 0) {
-		return 1;
-	} else {
-		return 0;
-	}
+	sock->set_timeout(SOCKET_TIMEOUT);	
+	nsapi_error_t returnCode = static_cast<TLSSocket*>(sock)->connect(socketAddress);
+	return returnCode == NSAPI_ERROR_OK ? 1 : 0;
+}
+
+int arduino::WiFiClient::connectSSL(IPAddress ip, uint16_t port) {
+	return connectSSL(WiFi.socketAddressFromIpAddress(ip, port));
+}
+
+int arduino::WiFiClient::connectSSL(const char *host, uint16_t port) {
+	SocketAddress socketAddress = SocketAddress();
+	socketAddress.set_port(port);
+	WiFi.getNetwork()->gethostbyname(host, &socketAddress);
+	return connectSSL(socketAddress);
 }
 
 size_t arduino::WiFiClient::write(uint8_t c) {

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -35,6 +35,7 @@ public:
   WiFiClient();
 
   uint8_t status();
+  int connect(SocketAddress socketAddress);
   int connect(IPAddress ip, uint16_t port);
   int connect(const char *host, uint16_t port);
   int connectSSL(IPAddress ip, uint16_t port);

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -38,6 +38,7 @@ public:
   int connect(SocketAddress socketAddress);
   int connect(IPAddress ip, uint16_t port);
   int connect(const char *host, uint16_t port);
+  int connectSSL(SocketAddress socketAddress);
   int connectSSL(IPAddress ip, uint16_t port);
   int connectSSL(const char *host, uint16_t port);
   size_t write(uint8_t);

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -33,8 +33,12 @@ size_t arduino::WiFiServer::write(const uint8_t *buf, size_t size) {
 }
 
 arduino::WiFiClient arduino::WiFiServer::available(uint8_t* status) {
-	WiFiClient ret;
-	TCPSocket* client = sock->accept();
-	ret.setSocket(client);
-	return ret;
+	WiFiClient client;
+	nsapi_error_t error;
+	TCPSocket* clientSocket = sock->accept(&error);
+	if(status != nullptr) {
+		*status = error == NSAPI_ERROR_OK ? 1 : 0;
+	}
+	client.setSocket(clientSocket);
+	return client;
 }

--- a/libraries/WiFi/src/WiFiUdp.cpp
+++ b/libraries/WiFi/src/WiFiUdp.cpp
@@ -43,10 +43,10 @@ uint8_t arduino::WiFiUDP::beginMulticast(IPAddress ip, uint16_t port) {
     if(begin(port) != 1){
         return 0;
     }
+    
+    SocketAddress socketAddress = WiFi.socketAddressFromIpAddress(ip, port);       
 
-    nsapi_addr_t multicastGroup = {NSAPI_IPv4, {ip[0], ip[1], ip[2], ip[3]}};       
-
-    if (_socket.join_multicast_group(SocketAddress(multicastGroup)) != NSAPI_ERROR_OK) {
+    if (_socket.join_multicast_group(socketAddress) != NSAPI_ERROR_OK) {
         printf("Error joining the multicast group\n");
         return 0;
     }
@@ -58,9 +58,8 @@ void arduino::WiFiUDP::stop() {
     _socket.close();    
 }
 
-int arduino::WiFiUDP::beginPacket(IPAddress ip, uint16_t port) {
-    nsapi_addr_t convertedIP = {NSAPI_IPv4, {ip[0], ip[1], ip[2], ip[3]}};   
-    _host = SocketAddress(convertedIP, port);
+int arduino::WiFiUDP::beginPacket(IPAddress ip, uint16_t port) {    
+    _host = WiFi.socketAddressFromIpAddress(ip, port);
     //If IP is null and port is 0 the initialization failed
     return (_host.get_ip_address() == nullptr && _host.get_port() == 0) ? 0 : 1;
 }


### PR DESCRIPTION
This PR adds missing functionality for:
```
int hostByName(const char* aHostname, IPAddress& aResult);
int connect(SocketAddress socketAddress);
int connect(IPAddress ip, uint16_t port);
int connectSSL(SocketAddress socketAddress);
int connectSSL(IPAddress ip, uint16_t port);
```
The problem is that when using SSL, the firmware size exceeds the available flash space.
Therefore this desperately asks for https://github.com/arduino/ArduinoCore-mbed/pull/26 to be merged.