### PR TITLE
Use consistent naming for Serial interfaces

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -22,10 +22,6 @@ jobs:
   compile-examples:
     runs-on: ubuntu-latest
 
-    env:
-      # sketch paths to compile (recursive) compatible with all boards
-      UNIVERSAL_SKETCH_PATHS: '"libraries/Scheduler"'
-
     strategy:
       fail-fast: false
 
@@ -39,13 +35,13 @@ jobs:
         include:
           - board:
               fqbn: arduino-beta:mbed:nano33ble
-            additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug"'
+            additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug" "libraries/Scheduler"'            
           - board:
               fqbn: arduino-beta:mbed:envie_m4
             additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" '
           - board:
               fqbn: arduino-beta:mbed:envie_m7
-            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST"'
+            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST" "libraries/Scheduler"'
 
     steps:
       - name: Checkout repository

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -127,19 +127,16 @@ extern analogin_config_t adcCurrentConfig;
 #endif
 
 #include "Serial.h"
+
 #if defined(SERIAL_CDC)
 #include "USB/PluggableUSBSerial.h"
 #define Serial SerialUSB
+#endif
+
 #define Serial1 _UART1_
 #define Serial2 _UART2_
 #define Serial3 _UART3_
 #define Serial4 _UART4_
-#else
-#define Serial  _UART1_
-#define Serial1 _UART2_
-#define Serial2 _UART3_
-#define Serial3 _UART4_
-#endif
 
 #include "overloads.h"
 #endif

--- a/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
@@ -1,3 +1,7 @@
+#ifdef CORE_CM4
+  #define Serial Serial1
+#endif
+
 uint8_t* bootloader_data = (uint8_t*)(0x801F000);
 
 void setup() {  

--- a/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
@@ -1,6 +1,10 @@
 #include "FlashIAP.h"
 #include "bootloader.h"
 
+#ifdef CORE_CM4
+  #define Serial Serial1
+#endif
+
 #define BOOTLOADER_ADDR   (0x8000000)
 mbed::FlashIAP flash;
 


### PR DESCRIPTION
After a discussion with @hpssjellis I concluded that it's confusing to map the serial interfaces to different UART port depending on the core. It's probably more understandable if the M4 doesn't support `Serial` for now, or to map it also to `_UART1_`. In the future we can add support for `Serial` to the M4 by piping the messages to the M7.