### PR TITLE
Provide better info about the bootloader data

### DIFF
--- a/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
@@ -4,16 +4,41 @@ void setup() {
   Serial.begin(115200);
   while (!Serial) {}
  
-  Serial.println("Validation: " + String(bootloader_data[0], HEX));
-  Serial.println("BL version: " + String(bootloader_data[1]));
-  Serial.println("Clock source: " + String(bootloader_data[2]));
-  Serial.println("USB Speed: " + String(bootloader_data[3]));
-  Serial.println("Ethernet: " + String(bootloader_data[4]));
-  Serial.println("Wifi: " + String(bootloader_data[5]));
-  Serial.println("RAM size: " + String(bootloader_data[6]));
-  Serial.println("QSPI size: " + String(bootloader_data[7]));
-  Serial.println("Video: " + String(bootloader_data[8]));
-  Serial.println("Crypto: " + String(bootloader_data[9]));
+  Serial.println("Magic Number (validation): " + String(bootloader_data[0], HEX));
+  Serial.println("Bootloader version: " + String(bootloader_data[1]));
+  Serial.println("Clock source: " + getClockSource(bootloader_data[2]));
+  Serial.println("USB Speed: " + getUSBSpeed(bootloader_data[3]));
+  Serial.println("Has Ethernet: " + String(bootloader_data[4] == 1 ? "Yes" : "No"));
+  Serial.println("Has WiFi module: " + String(bootloader_data[5] == 1 ? "Yes" : "No"));
+  Serial.println("RAM size: " + String(bootloader_data[6]) + " MB");
+  Serial.println("QSPI size: " + String(bootloader_data[7]) + " MB");
+  Serial.println("Has Video output: " + String(bootloader_data[8] == 1 ? "Yes" : "No"));
+  Serial.println("Has Crypto chip: " + String(bootloader_data[9] == 1 ? "Yes" : "No"));
+}
+
+String getUSBSpeed(uint8_t flag) {
+  switch (flag){
+  case 1:
+    return "USB 2.0/Hi-Speed (480 Mbps)";
+  case 2:
+    return "USB 1.1/Full-Speed (12 Mbps)";
+  default:
+    return "N/A";
+  }
+}
+
+String getClockSource(uint8_t flag) {
+  switch (flag){
+  case 0x8:
+    return "External clock (ST Link MCO)";
+  case 0x4:
+    return "External xtal (X3 on board - not provided by default)";
+  case 0x2: 
+    return "HSI internal clock"; 
+  default:
+    return "N/A";
+  }
+
 }
 
 void loop() {  


### PR DESCRIPTION
With this PR the output of the bootloader info sketch should be easier to understand. It looks e.g. like the following:
```
Magic Number (validation): a0
Bootloader version: 20
Clock source: External clock (ST Link MCO)
USB Speed: USB 2.0/Hi-Speed (480 Mbps)
Has Ethernet: Yes
Has WiFi module: Yes
RAM size: 8 MB
QSPI size: 16 MB
Has Video output: Yes
Has Crypto chip: Yes

```