### PR TITLE
Fix incorrect bootloader version check

### DIFF
--- a/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
@@ -30,11 +30,11 @@ String getUSBSpeed(uint8_t flag) {
 String getClockSource(uint8_t flag) {
   switch (flag){
   case 0x8:
-    return "External clock (ST Link MCO)";
+    return "External oscillator";
   case 0x4:
-    return "External xtal (X3 on board - not provided by default)";
+    return "External crystal";
   case 0x2: 
-    return "HSI internal clock"; 
+    return "Internal clock"; 
   default:
     return "N/A";
   }

--- a/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_getBootloaderInfo/PortentaH7_getBootloaderInfo.ino
@@ -38,7 +38,6 @@ String getClockSource(uint8_t flag) {
   default:
     return "N/A";
   }
-
 }
 
 void loop() {  

--- a/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
@@ -15,7 +15,7 @@ void setup() {
   uint8_t availableBootloaderVersion = (envie_bootloader_mbed_bin + bootloader_data_offset)[1];
 
   Serial.println("Magic Number (validation): " + String(bootloader_data[0], HEX));
-  Serial.println("Bootloader version: " + String(bootloader_data[1]));
+  Serial.println("Bootloader version: " + String(currentBootloaderVersion));
   Serial.println("Clock source: " + getClockSource(bootloader_data[2]));
   Serial.println("USB Speed: " + getUSBSpeed(bootloader_data[3]));
   Serial.println("Has Ethernet: " + String(bootloader_data[4] == 1 ? "Yes" : "No"));

--- a/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
@@ -29,8 +29,11 @@ void setup() {
     Serial.print("\nA new bootloader version is available: v" + String(availableBootloaderVersion));
     Serial.println(" (Your version: v" + String(currentBootloaderVersion) + ")");
     Serial.println("Do you want to update the bootloader? Y/[n]");
+  } else if(availableBootloaderVersion < currentBootloaderVersion){ 
+    Serial.println("\nA newer bootloader version is already installed: v" + String(currentBootloaderVersion));    
+    Serial.println("Do you want to downgrade the bootloader to v" + String(availableBootloaderVersion) + "? Y/[n]");
   } else {
-    Serial.println("The latest version of the bootloader is already installed (v" + String(availableBootloaderVersion) + ").");
+    Serial.println("\nThe latest version of the bootloader is already installed (v" + String(currentBootloaderVersion) + ").");
     Serial.println("Do you want to update the bootloader anyway? Y/[n]");
   }
   


### PR DESCRIPTION
The bootloader updater sketch didn't dynamically check for an updated version. This PR fixes that plus improves the clarity and understandability of the bootloader information.