### PR TITLE
Nudge user to use the M7 for bootloader and WiFi updates

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -42,7 +42,7 @@ jobs:
             additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug"'
           - board:
               fqbn: arduino:mbed:envie_m4
-            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" '
+            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_Video"'
           - board:
               fqbn: arduino:mbed:envie_m7
             additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST"'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -45,7 +45,7 @@ jobs:
             additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_Video"'
           - board:
               fqbn: arduino:mbed:envie_m7
-            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST"'
+            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST" "libraries/WiFi"'
 
     steps:
       - name: Checkout repository

--- a/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
+++ b/libraries/Portenta_System/examples/PortentaH7_updateBootloader/PortentaH7_updateBootloader.ino
@@ -1,6 +1,10 @@
 #include "FlashIAP.h"
 #include "bootloader.h"
 
+#ifndef CORE_CM7  
+  #error Update the bootloader by uploading the sketch to the M7 core instead of the M4 core.
+#endif
+
 #define BOOTLOADER_ADDR   (0x8000000)
 mbed::FlashIAP flash;
 

--- a/libraries/WiFi/examples/PortentaWiFiFirmwareUpdater/PortentaWiFiFirmwareUpdater.ino
+++ b/libraries/WiFi/examples/PortentaWiFiFirmwareUpdater/PortentaWiFiFirmwareUpdater.ino
@@ -4,6 +4,10 @@
 #include "wiced_resource.h"
 #include "certificates.h"
 
+#ifndef CORE_CM7  
+  #error Update the WiFi firmware by uploading the sketch to the M7 core instead of the M4 core.
+#endif
+
 QSPIFBlockDevice root(PD_11, PD_12, PF_7, PD_13,  PF_10, PG_6, QSPIF_POLARITY_MODE_1, 40000000);
 mbed::MBRBlockDevice wifi_data(&root, 1);
 mbed::FATFileSystem wifi_data_fs("wlan");


### PR DESCRIPTION
In my opinion it doesn't make much sense to allow the users to upload the bootloader / wifi FW update sketch to the M4 as they would need to force-boot the M4 on the M7 just for that. If someone accidentally chooses the M4 core they may wonder why nothing happens.
This PR forces the users to use the M7 for those updates.