### PR TITLE
Makes available() non-blocking (fixes #76)

### DIFF
--- a/libraries/WiFi/examples/PortentaWiFiFirmwareUpdater/PortentaWiFiFirmwareUpdater.ino
+++ b/libraries/WiFi/examples/PortentaWiFiFirmwareUpdater/PortentaWiFiFirmwareUpdater.ino
@@ -36,7 +36,7 @@ void setup() {
     Serial.println("No filesystem containing the WiFi firmware was found.");
     Serial.println("Usually that means that the WiFi firmware has not been installed yet"
                   " or was overwritten with another firmware.\n");
-    Serial.println("Formatting the filsystem to install the firmware and certificates...\n");
+    Serial.println("Formatting the filesystem to install the firmware and certificates...\n");
     err = wifi_data_fs.reformat(&wifi_data);
   }
 

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -7,6 +7,10 @@ extern WiFiClass WiFi;
 #define WIFI_TCP_BUFFER_SIZE        1508
 #endif
 
+#ifndef SOCKET_TIMEOUT
+#define SOCKET_TIMEOUT 1500
+#endif
+
 #define MAX_PENDING_CONNECTIONS 5
 
 arduino::WiFiServer::WiFiServer(uint16_t port) {
@@ -41,7 +45,7 @@ size_t arduino::WiFiServer::write(uint8_t c) {
 }
 
 size_t arduino::WiFiServer::write(const uint8_t *buf, size_t size) {
-	_socket->set_blocking(true);
+	_socket->set_timeout(SOCKET_TIMEOUT);
 	_socket->send(buf, size);
 }
 

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -28,7 +28,12 @@ void arduino::WiFiServer::begin() {
 	_socketState = SOCK_LISTEN;
 }
 
+void arduino::WiFiServer::end() {
+	if (_socket != NULL) {
+		_socket->close();
+		_socket = NULL;
 	}
+	_socketState = SOCK_CLOSED;
 }
 
 size_t arduino::WiFiServer::write(uint8_t c) {

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -25,7 +25,7 @@ void arduino::WiFiServer::begin() {
 }
 
 size_t arduino::WiFiServer::write(uint8_t c) {
-	sock->send(&c, 1);
+	write(&c, 1);	
 }
 
 size_t arduino::WiFiServer::write(const uint8_t *buf, size_t size) {
@@ -35,10 +35,17 @@ size_t arduino::WiFiServer::write(const uint8_t *buf, size_t size) {
 arduino::WiFiClient arduino::WiFiServer::available(uint8_t* status) {
 	WiFiClient client;
 	nsapi_error_t error;
+	sock->set_blocking(false);
 	TCPSocket* clientSocket = sock->accept(&error);
+	
 	if(status != nullptr) {
 		*status = error == NSAPI_ERROR_OK ? 1 : 0;
 	}
-	client.setSocket(clientSocket);
+
+	if(error == NSAPI_ERROR_OK){
+		client.setSocket(clientSocket);		
+	}
+
+	sock->set_blocking(true);
 	return client;
 }

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -37,6 +37,7 @@ public:
   WiFiServer(uint16_t);
   arduino::WiFiClient available(uint8_t* status = NULL);
   void begin();
+  void end();
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   uint8_t status();

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -31,7 +31,8 @@ class WiFiClient;
 class WiFiServer : public arduino::Server {
 private:
   uint16_t _port;
-  TCPSocket* sock;
+  TCPSocket* _socket;
+  socket_state _socketState;
 public:
   WiFiServer(uint16_t);
   arduino::WiFiClient available(uint8_t* status = NULL);


### PR DESCRIPTION
This PR makes `available` non-blocking and thus fixes https://github.com/arduino/ArduinoCore-mbed/issues/76. I'm not sure if we should also go with a client socket re-use approach as in the NINA library: https://github.com/arduino-libraries/WiFiNINA/blob/master/src/WiFiServer.cpp#L48
I currently struggle to see the use case for this as it's the caller's responsibility to keep the client instance which wraps the socket. Then again my networking knowledge has faded, maybe I'm overlooking something :-)

Btw. using the `WiFiClient` class on a server side application is a bit confusing imho