### PR TITLE
Make available() method in WiFiClient non-blocking

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -3,7 +3,7 @@
 extern WiFiClass WiFi;
 
 #ifndef SOCKET_TIMEOUT
-#define SOCKET_TIMEOUT 1000
+#define SOCKET_TIMEOUT 1500
 #endif
 
 arduino::WiFiClient::WiFiClient() {

--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -15,8 +15,8 @@ uint8_t arduino::WiFiClient::status() {
 
 void arduino::WiFiClient::receiveData() {
 	uint8_t data[WIFI_RECEIVE_BUFFER_SIZE];
-	sock->set_blocking(false);
-    int receivedBytes = sock->recv(data, rxBuffer.availableForStore());
+	_socket->set_blocking(false);
+    int receivedBytes = _socket->recv(data, rxBuffer.availableForStore());
 
     for (int i = 0; i < receivedBytes; ++i) {
       rxBuffer.store_char(data[i]);
@@ -27,16 +27,16 @@ void arduino::WiFiClient::receiveData() {
 }
 
 int arduino::WiFiClient::connect(SocketAddress socketAddress) {
-	if (sock == NULL) {
-		sock = new TCPSocket();		
-		if(static_cast<TCPSocket*>(sock)->open(WiFi.getNetwork()) != NSAPI_ERROR_OK){
+	if (_socket == NULL) {
+		_socket = new TCPSocket();		
+		if(static_cast<TCPSocket*>(_socket)->open(WiFi.getNetwork()) != NSAPI_ERROR_OK){
 			return 0;
 		}
 	}
 	//sock->sigio(mbed::callback(this, &WiFiClient::getStatus));
 	//sock->set_blocking(false);
-	sock->set_timeout(SOCKET_TIMEOUT);		
-	nsapi_error_t returnCode = static_cast<TCPSocket*>(sock)->connect(socketAddress);
+	_socket->set_timeout(SOCKET_TIMEOUT);		
+	nsapi_error_t returnCode = static_cast<TCPSocket*>(_socket)->connect(socketAddress);
 	return returnCode == NSAPI_ERROR_OK ? 1 : 0;
 }
 
@@ -52,17 +52,17 @@ int arduino::WiFiClient::connect(const char *host, uint16_t port) {
 }
 
 int arduino::WiFiClient::connectSSL(SocketAddress socketAddress){
-	if (sock == NULL) {
-		sock = new TLSSocket();
-		if(static_cast<TLSSocket*>(sock)->open(WiFi.getNetwork()) != NSAPI_ERROR_OK){
+	if (_socket == NULL) {
+		_socket = new TLSSocket();
+		if(static_cast<TLSSocket*>(_socket)->open(WiFi.getNetwork()) != NSAPI_ERROR_OK){
 			return 0;
 		}
 	}
 	if (beforeConnect) {
 		beforeConnect();
 	}
-	sock->set_timeout(SOCKET_TIMEOUT);	
-	nsapi_error_t returnCode = static_cast<TLSSocket*>(sock)->connect(socketAddress);
+	_socket->set_timeout(SOCKET_TIMEOUT);	
+	nsapi_error_t returnCode = static_cast<TLSSocket*>(_socket)->connect(socketAddress);
 	return returnCode == NSAPI_ERROR_OK ? 1 : 0;
 }
 
@@ -82,8 +82,8 @@ size_t arduino::WiFiClient::write(uint8_t c) {
 }
 
 size_t arduino::WiFiClient::write(const uint8_t *buf, size_t size) {
-	sock->set_timeout(SOCKET_TIMEOUT);
-	sock->send(buf, size);
+	_socket->set_timeout(SOCKET_TIMEOUT);
+	_socket->send(buf, size);
 }
 
 int arduino::WiFiClient::available() {
@@ -128,9 +128,9 @@ void arduino::WiFiClient::flush() {
 }
 
 void arduino::WiFiClient::stop() {
-	if (sock != NULL) {
-		sock->close();
-		sock = NULL;
+	if (_socket != NULL) {
+		_socket->close();
+		_socket = NULL;
 	}
 }
 

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -27,6 +27,10 @@
 #include "TLSSocket.h"
 #include "TCPSocket.h"
 
+#ifndef WIFI_RECEIVE_BUFFER_SIZE
+#define WIFI_RECEIVE_BUFFER_SIZE        256
+#endif
+
 namespace arduino {
 
 class WiFiClient : public arduino::Client {
@@ -78,11 +82,11 @@ protected:
 private:
   static uint16_t _srcport;
   Socket* sock;
-  RingBufferN<256> rxBuffer;
+  RingBufferN<WIFI_RECEIVE_BUFFER_SIZE> rxBuffer;
   uint8_t _status;
   mbed::Callback<int(void)> beforeConnect;
 
-  void getStatus();
+  void receiveData();
 };
 
 }

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -58,11 +58,11 @@ public:
   void stop();
   uint8_t connected();
   operator bool() {
-    return sock != NULL;
+    return _socket != NULL;
   }
 
-  void setSocket(Socket* _sock) {
-    sock = _sock;
+  void setSocket(Socket* sock) {
+    _socket = sock;
   }
 
   IPAddress remoteIP();
@@ -81,7 +81,7 @@ protected:
 
 private:
   static uint16_t _srcport;
-  Socket* sock;
+  Socket* _socket;
   RingBufferN<WIFI_RECEIVE_BUFFER_SIZE> rxBuffer;
   uint8_t _status;
   mbed::Callback<int(void)> beforeConnect;

--- a/libraries/WiFi/src/WiFiSSLClient.h
+++ b/libraries/WiFi/src/WiFiSSLClient.h
@@ -38,16 +38,16 @@ public:
     return connectSSL(host, port);
   }
   void stop() {
-    if (sock != NULL) {
-      sock->close();
-      delete ((TLSSocket*)sock);
-      sock = NULL;
+    if (_socket != NULL) {
+      _socket->close();
+      delete (static_cast<TLSSocket*>(_socket));
+      _socket = NULL;
     }
   }
 
 private:
   int setRootCA() {
-    return ((TLSSocket*)sock)->set_root_ca_cert("/wlan/", 0);
+    return (static_cast<TLSSocket*>(_socket)->set_root_ca_cert("/wlan/", 0));
   }
 };
 


### PR DESCRIPTION
This PR makes `available` method in WiFiClient non-blocking and adds a timeout for the `write` method.