### PR TITLE
Override max num BLE connections to allow up to 5 connections

### DIFF
--- a/variants/ARDUINO_NANO33BLE/conf/mbed_app.json
+++ b/variants/ARDUINO_NANO33BLE/conf/mbed_app.json
@@ -13,6 +13,7 @@
       "platform.default-serial-baud-rate": 115200,
       "platform.callback-nontrivial": true,
       "rtos.main-thread-stack-size": 32768,
+      "cordio.max-connections": 5,
       "target.mbed_app_start": "0x10000"
     }
   }

--- a/variants/PORTENTA_H7_M4/conf/mbed_app.json
+++ b/variants/PORTENTA_H7_M4/conf/mbed_app.json
@@ -7,6 +7,7 @@
       "platform.default-serial-baud-rate": 115200,
       "platform.callback-nontrivial": true,
       "rtos.main-thread-stack-size": 32768,
+      "cordio.max-connections": 5,
       "target.macros_add": [
         "MBED_HEAP_STATS_ENABLED=1",
         "MBED_STACK_STATS_ENABLED=1",

--- a/variants/PORTENTA_H7_M7/conf/mbed_app.json
+++ b/variants/PORTENTA_H7_M7/conf/mbed_app.json
@@ -7,6 +7,7 @@
       "platform.default-serial-baud-rate": 115200,
       "platform.callback-nontrivial": true,
       "rtos.main-thread-stack-size": 32768,
+      "cordio.max-connections": 5,
       "target.mbed_app_start": "0x8040000",
       "target.macros_add": [
         "MBED_HEAP_STATS_ENABLED=1",


### PR DESCRIPTION
This patch will allow to connect up to 5 BLE peripherals to a BLE central device. It will take effect at the next core compilation, where DM_CONN_MAX will be set to 5 (now it is 3).
This will fix [ArduinoBLE#116](https://github.com/arduino-libraries/ArduinoBLE/issues/116) and [ArduinoCore-nRF528#40](https://github.com/arduino/ArduinoCore-nRF528x-mbedos/issues/40).