### PR TITLE
Fix: Allow HardwareI2C::requestFrom to return values > 256

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -72,7 +72,7 @@ uint8_t arduino::MbedI2C::endTransmission(void) {
 	return endTransmission(true);
 }
 
-uint8_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len, bool stopBit) {
+size_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len, bool stopBit) {
 	char buf[256];
 	int ret = master->read(address << 1, buf, len, !stopBit);
 	if (ret != 0) {
@@ -84,7 +84,7 @@ uint8_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len, bool stopBit)
 	return len;
 }
 
-uint8_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len) {
+size_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len) {
 	return requestFrom(address, len, true);
 }
 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -43,8 +43,8 @@ class MbedI2C : public HardwareI2C
     virtual uint8_t endTransmission(bool stopBit);
     virtual uint8_t endTransmission(void);
 
-    virtual uint8_t requestFrom(uint8_t address, size_t len, bool stopBit);
-    virtual uint8_t requestFrom(uint8_t address, size_t len);
+    virtual size_t requestFrom(uint8_t address, size_t len, bool stopBit);
+    virtual size_t requestFrom(uint8_t address, size_t len);
 
     virtual void onReceive(void(*)(int));
     virtual void onRequest(void(*)(void));


### PR DESCRIPTION
Changing return type of `requestFrom` from `uint8_t` to `size_t` allows the function to return the correct amount of bytes read (since internally it's already a `size_t` which is downcast to a `uint8_t` upon returning it).

Merging this PR is a pre-condition for merging https://github.com/arduino/ArduinoCore-API/pull/132.

@facchinm Let's coordinate to get this done.