### PR TITLE
Use ArduinoCore-API:master for CI build.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: arduino/ArduinoCore-API
-          ref: namespace_arduino
           path: ArduinoCore-API
 
       - name: Remove old symlink to api


### PR DESCRIPTION
Since the most advanced code of the `ArduinoCore-API` repository now reside within the `master` branch we should check that one out instead of the outdated branch `namespace_arduino`.