### PR TITLE
UART: Allow baud rate changes

### DIFF
--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -75,6 +75,8 @@ void UART::begin(unsigned long baudrate, uint16_t config) {
 void UART::begin(unsigned long baudrate) {
 	if (_serial == NULL) {
 		_serial = new mbed::UnbufferedSerial(tx, rx, baudrate);
+	} else {
+		_serial->baud(baudrate);
 	}
 	if (rts != NC) {
 		_serial->set_flow_control(mbed::SerialBase::Flow::RTSCTS, rts, cts);


### PR DESCRIPTION
Allows begin() to alter the baud rate if _serial objected already created.