### PR TITLE
Remove api symlink deletion step from CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -58,9 +58,6 @@ jobs:
           repository: arduino/ArduinoCore-API
           path: ArduinoCore-API
 
-      - name: Remove old symlink to api
-        run: rm "$GITHUB_WORKSPACE/cores/arduino/api"
-
       - name: Install ArduinoCore-API
         run: mv "$GITHUB_WORKSPACE/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"   
 


### PR DESCRIPTION
The symlink in the core library for ArduinoCore-API has been removed (https://github.com/arduino/ArduinoCore-mbed/commit/ca397e88926c16ccfd7531f842a2d8f0971dcffc), resulting in the step of the CI workflow to remove the now-nonexistent symlink was failing.