### PR TITLE
[WIP] Improve compile time

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -23,24 +23,8 @@
 #if !defined(Arduino_h) && !defined(ARDUINO_LIB_DISCOVERY_PHASE)
 #define Arduino_h
 
-#if defined(__cplusplus)
 #if !defined(ARDUINO_AS_MBED_LIBRARY)
-
 #include "pinmode_arduino.h"
-
-#ifdef F
-#define Arduino_F F
-#undef F
-#endif // F (mbed included after arduino.h)
-#define F Mbed_F
-#endif // !ARDUINO_AS_MBED_LIBRARY
-#include "mbed_config.h"
-#undef F
-#endif //__cplusplus
-
-#if defined(ARDUINO_AS_MBED_LIBRARY)
-#define PinMode ArduinoPinMode
-#define Arduino_F F
 #endif
 
 #include "api/ArduinoAPI.h"

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -35,11 +35,6 @@
 #define F Mbed_F
 #endif // !ARDUINO_AS_MBED_LIBRARY
 #include "mbed_config.h"
-#include "mbed/drivers/InterruptIn.h"
-#include "mbed/drivers/PwmOut.h"
-#include "mbed/drivers/AnalogIn.h"
-#include "mbed/drivers/DigitalInOut.h"
-#include "mbed.h"
 #undef F
 #endif //__cplusplus
 
@@ -91,28 +86,15 @@ void analogWriteResolution(int bits);
 
 #ifdef __cplusplus
 // Types used for the table below
-typedef struct _PinDescription
-{
-  PinName name;
-  mbed::InterruptIn* irq;
-  mbed::PwmOut* pwm;
-  mbed::DigitalInOut* gpio;
-} PinDescription ;
-
-typedef struct _AnalogPinDescription
-{
-  PinName name;
-  mbed::AnalogIn* adc;
-} AnalogPinDescription ;
-
-int PinNameToIndex(PinName P);
+typedef struct _PinDescription PinDescription;
+typedef struct _AnalogPinDescription AnalogPinDescription;
 
 // Pins table to be instantiated into variant.cpp
 extern PinDescription g_APinDescription[];
 extern AnalogPinDescription g_AAnalogPinDescription[];
 
 #ifdef ANALOG_CONFIG
-
+#include "hal/analogin_api.h"
 typedef enum _AnalogReferenceMode AnalogReferenceMode;
 void analogReference(uint8_t mode);
 /* nRF specific function to change analog acquisition time */
@@ -128,8 +110,7 @@ extern analogin_config_t adcCurrentConfig;
 
 #include "Serial.h"
 #if defined(SERIAL_CDC)
-#include "USB/PluggableUSBSerial.h"
-#define Serial SerialUSB
+#define Serial _UART_USB_
 #else
 #define Serial _UART1_
 #endif

--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -30,6 +30,16 @@
 #include "api/ArduinoAPI.h"
 
 #if defined(__cplusplus)
+
+#undef F
+// C++11 F replacement declaration
+template <typename T1>
+auto F(T1&& A)
+  -> const arduino::__FlashStringHelper*
+{
+  return (const arduino::__FlashStringHelper*)A;
+}
+
 #if !defined(ARDUINO_AS_MBED_LIBRARY)
 using namespace arduino;
 #endif

--- a/cores/arduino/Interrupts.cpp
+++ b/cores/arduino/Interrupts.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "Arduino.h"
+#include "pinDefinitions.h"
 
 void detachInterrupt(PinName interruptNum) {
   pin_size_t idx = PinNameToIndex(interruptNum);

--- a/cores/arduino/Serial.cpp
+++ b/cores/arduino/Serial.cpp
@@ -96,6 +96,7 @@ void UART::begin(unsigned long baudrate) {
 #endif
 	if (_serial == NULL) {
 		_serial = new mbed_serial;
+		_serial->obj = NULL;
 	}
 	if (_serial->obj == NULL) {
 		_serial->obj = new mbed::UnbufferedSerial(tx, rx, baudrate);

--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -23,18 +23,24 @@
 #include "api/RingBuffer.h"
 #include "Arduino.h"
 #include "api/HardwareSerial.h"
-#include "mbed/drivers/UnbufferedSerial.h"
+#include "PinNames.h"
 
 #ifdef __cplusplus
 
 #ifndef __ARDUINO_UART_IMPLEMENTATION__
 #define __ARDUINO_UART_IMPLEMENTATION__
 
+typedef struct _mbed_serial mbed_serial;
+typedef struct _mbed_usb_serial mbed_usb_serial;
+
 namespace arduino {
 
 class UART : public HardwareSerial {
 	public:
-		UART(int _tx, int _rx, int _rts, int _cts) : tx((PinName)_tx), rx((PinName)_rx), rts((PinName)_rts), cts((PinName)_cts) {};
+		UART(int _tx, int _rx, int _rts, int _cts) : tx((PinName)_tx), rx((PinName)_rx), rts((PinName)_rts), cts((PinName)_cts) {}
+		UART() {
+			is_usb = true;
+		}
 		void begin(unsigned long);
 		void begin(unsigned long baudrate, uint16_t config);
 		void end();
@@ -53,10 +59,12 @@ class UART : public HardwareSerial {
 		bool _block;
 		// See https://github.com/ARMmbed/mbed-os/blob/f5b5989fc81c36233dbefffa1d023d1942468d42/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c#L76
 		const size_t WRITE_BUFF_SZ = 32;
-		mbed::UnbufferedSerial* _serial = NULL;
+		mbed_serial* _serial = NULL;
+		mbed_usb_serial* _usb_serial = NULL;
 		PinName tx, rx, rts, cts;
 		RingBufferN<256> rx_buffer;
 		uint8_t intermediate_buf[4];
+		bool is_usb = false;
 };
 }
 
@@ -64,6 +72,7 @@ extern arduino::UART _UART1_;
 extern arduino::UART _UART2_;
 extern arduino::UART _UART3_;
 extern arduino::UART _UART4_;
+extern arduino::UART _UART_USB_;
 
 #endif
 #endif

--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -1,4 +1,5 @@
 #include "Arduino.h"
+#include "pinDefinitions.h"
 #include "mbed.h"
 
 using namespace std::chrono_literals;

--- a/cores/arduino/USB/USBCDC.cpp
+++ b/cores/arduino/USB/USBCDC.cpp
@@ -535,7 +535,7 @@ const uint8_t *USBCDC::configuration_desc(uint8_t index)
         0x02,                   // bInterfaceClass
         0x02,                   // bInterfaceSubClass
         0x01,                   // bInterfaceProtocol
-        (extraDescriptor != NULL) ? 0x5 : 0x0, // iInterface
+        (extraDescriptor != NULL) ? (uint8_t)0x5 : (uint8_t)0x0, // iInterface
 
         // CDC Header Functional Descriptor, CDC Spec 5.2.3.1, Table 26
         5,                      // bFunctionLength

--- a/cores/arduino/macros.h
+++ b/cores/arduino/macros.h
@@ -23,12 +23,8 @@
 #pragma once
 #ifdef USE_ARDUINO_PINOUT
 
-#define analogPinToPinName(P)       (P >= PINS_COUNT ? NC : P < A0 ? g_APinDescription[P+A0].name : g_APinDescription[P].name)
-#define analogPinToAdcObj(P)		    (P < A0 ? g_AAnalogPinDescription[P].adc : g_AAnalogPinDescription[P-A0].adc)
-#define digitalPinToPinName(P)      (P >= PINS_COUNT ? NC : g_APinDescription[P].name)
-#define digitalPinToInterruptObj(P) (g_APinDescription[P].irq)
-#define digitalPinToPwm(P)          (g_APinDescription[P].pwm)
-#define digitalPinToGpio(P)         (g_APinDescription[P].gpio)
+#include <Arduino.h>
+#include <PinNames.h>
 
 // this is needed for backwards compatibility
 #define digitalPinToInterrupt(P)    (P)

--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -18,7 +18,7 @@
 */
 
 #include <Arduino.h>
-#include <USB/PluggableUSBDevice.h>
+#include <USB/PluggableUSBSerial.h>
 
 // Declared weak in Arduino.h to allow user redefinitions.
 int atexit(void (* /*func*/ )()) { return 0; }

--- a/cores/arduino/mbed/platform/Callback.h
+++ b/cores/arduino/mbed/platform/Callback.h
@@ -36,11 +36,6 @@
 #define MBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL 1
 #endif
 
-#ifdef F
-#undef F
-#define F _F
-#endif
-
 namespace mbed {
 /** \addtogroup platform-public-api */
 /** @{*/

--- a/cores/arduino/mbed/platform/Callback.h
+++ b/cores/arduino/mbed/platform/Callback.h
@@ -36,6 +36,7 @@
 #define MBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL 1
 #endif
 
+#define F _F
 
 namespace mbed {
 /** \addtogroup platform-public-api */

--- a/cores/arduino/mbed/platform/Callback.h
+++ b/cores/arduino/mbed/platform/Callback.h
@@ -36,7 +36,10 @@
 #define MBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL 1
 #endif
 
+#ifdef F
+#undef F
 #define F _F
+#endif
 
 namespace mbed {
 /** \addtogroup platform-public-api */

--- a/cores/arduino/pinDefinitions.h
+++ b/cores/arduino/pinDefinitions.h
@@ -1,0 +1,31 @@
+#include "mbed/drivers/InterruptIn.h"
+#include "mbed/drivers/PwmOut.h"
+#include "mbed/drivers/AnalogIn.h"
+#include "mbed/drivers/DigitalInOut.h"
+
+struct _PinDescription
+{
+  PinName name;
+  mbed::InterruptIn* irq;
+  mbed::PwmOut* pwm;
+  mbed::DigitalInOut* gpio;
+};
+
+struct _AnalogPinDescription
+{
+  PinName name;
+  mbed::AnalogIn* adc;
+};
+
+#define analogPinToPinName(P)       (P >= PINS_COUNT ? NC : P < A0 ? g_APinDescription[P+A0].name : g_APinDescription[P].name)
+#define analogPinToAdcObj(P)		(P < A0 ? g_AAnalogPinDescription[P].adc : g_AAnalogPinDescription[P-A0].adc)
+//#define digitalPinToPinName(P)      (P >= PINS_COUNT ? NC : g_APinDescription[P].name)
+#define digitalPinToInterruptObj(P) (g_APinDescription[P].irq)
+#define digitalPinToPwm(P)          (g_APinDescription[P].pwm)
+#define digitalPinToGpio(P)         (g_APinDescription[P].gpio)
+
+inline PinName digitalPinToPinName(int P) {
+	return (P >= PINS_COUNT ? NC : g_APinDescription[P].name);
+};
+
+int PinNameToIndex(PinName P);

--- a/cores/arduino/pinDefinitions.h
+++ b/cores/arduino/pinDefinitions.h
@@ -27,7 +27,7 @@ struct _AnalogPinDescription
 #ifdef __cplusplus__
 extern "C" {
 #endif
-inline PinName digitalPinToPinName(int P) {
+inline PinName digitalPinToPinName(pin_size_t P) {
 	return (P >= PINS_COUNT ? NC : g_APinDescription[P].name);
 };
 #ifdef __cplusplus__

--- a/cores/arduino/pinDefinitions.h
+++ b/cores/arduino/pinDefinitions.h
@@ -24,8 +24,14 @@ struct _AnalogPinDescription
 #define digitalPinToPwm(P)          (g_APinDescription[P].pwm)
 #define digitalPinToGpio(P)         (g_APinDescription[P].gpio)
 
+#ifdef __cplusplus__
+extern "C" {
+#endif
 inline PinName digitalPinToPinName(int P) {
 	return (P >= PINS_COUNT ? NC : g_APinDescription[P].name);
 };
+#ifdef __cplusplus__
+}
+#endif
 
 int PinNameToIndex(PinName P);

--- a/cores/arduino/pinToIndex.cpp
+++ b/cores/arduino/pinToIndex.cpp
@@ -1,4 +1,5 @@
 #include "Arduino.h"
+#include "pinDefinitions.h"
 
 int PinNameToIndex(PinName P) {
   for (pin_size_t i=0; i < PINS_COUNT; i++) {

--- a/cores/arduino/wiring_analog.cpp
+++ b/cores/arduino/wiring_analog.cpp
@@ -23,6 +23,7 @@
 #include "Arduino.h"
 #include "pins_arduino.h"
 #include "mbed/drivers/AnalogIn.h"
+#include "pinDefinitions.h"
 
 static int write_resolution = 8;
 static int read_resolution = 10;

--- a/cores/arduino/wiring_digital.cpp
+++ b/cores/arduino/wiring_digital.cpp
@@ -23,6 +23,7 @@
 #include "Arduino.h"
 #include "pins_arduino.h"
 #include "mbed.h"
+#include "pinDefinitions.h"
 
 void pinMode(PinName pin, PinMode mode)
 {

--- a/cores/arduino/wiring_pulse.cpp
+++ b/cores/arduino/wiring_pulse.cpp
@@ -2,6 +2,7 @@
 
 #if defined(ARDUINO_ARCH_NRF52840)
 
+#include "mbed.h"
 #include <hal/nrf_timer.h>
 #include <hal/nrf_gpiote.h>
 #include <hal/nrf_gpio.h>

--- a/libraries/KernelDebug/src/KernelDebug.h
+++ b/libraries/KernelDebug/src/KernelDebug.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <mbed.h>
+#include <pinDefinitions.h>
 
 
 namespace arduino {

--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -20,6 +20,7 @@
 #define _PDM_H_INCLUDED
 
 #include <Arduino.h>
+#include <pinDefinitions.h>
 
 #include "utility/PDMDoubleBuffer.h"
 

--- a/libraries/RPC/RPC_client.h
+++ b/libraries/RPC/RPC_client.h
@@ -1,4 +1,5 @@
 #include "Arduino.h"
+#include "mbed.h"
 #include "rpc/dispatcher.h"
 
 //forward declaration

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -21,13 +21,24 @@
 */
 
 #include "SPI.h"
+#include "pinDefinitions.h"
+#if !defined(ARDUINO_AS_MBED_LIBRARY)
+#include "drivers/SPIMaster.h"
+#else
+#include "drivers/SPI.h"
+#endif
+
+struct _mbed_spi {
+  mbed::SPI* obj;
+};
+
 
 arduino::MbedSPI::MbedSPI(int miso, int mosi, int sck) : _miso(miso), _mosi(mosi), _sck(sck) {
 }
 
 uint8_t arduino::MbedSPI::transfer(uint8_t data) {
     uint8_t ret;
-    dev->write((const char*)&data, 1, (char*)&ret, 1);
+    dev->obj->write((const char*)&data, 1, (char*)&ret, 1);
     return ret;
 }
 
@@ -47,7 +58,7 @@ uint16_t arduino::MbedSPI::transfer16(uint16_t data) {
 }
 
 void arduino::MbedSPI::transfer(void *buf, size_t count) {
-    dev->write((const char*)buf, count, (char*)buf, count);
+    dev->obj->write((const char*)buf, count, (char*)buf, count);
 }
 
 void arduino::MbedSPI::usingInterrupt(int interruptNumber) {
@@ -60,8 +71,8 @@ void arduino::MbedSPI::notUsingInterrupt(int interruptNumber) {
 
 void arduino::MbedSPI::beginTransaction(SPISettings settings) {
     if (settings != this->settings) {
-        dev->format(8, settings.getDataMode());
-        dev->frequency(settings.getClockFreq());
+        dev->obj->format(8, settings.getDataMode());
+        dev->obj->frequency(settings.getClockFreq());
         this->settings = settings;
     }
 }
@@ -79,12 +90,17 @@ void arduino::MbedSPI::detachInterrupt() {
 }
 
 void arduino::MbedSPI::begin() {
-    dev = new mbed::SPI((PinName)_mosi, (PinName)_miso, (PinName)_sck);
+    if (dev == NULL) {
+      dev = new mbed_spi;
+    }
+    if (dev->obj == NULL) {
+      dev->obj = new mbed::SPI((PinName)_mosi, (PinName)_miso, (PinName)_sck);
+    }
 }
 
 void arduino::MbedSPI::end() {
-    if (dev != NULL) {
-        delete dev;
+    if (dev->obj != NULL) {
+        delete dev->obj;
     }
 }
 

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -20,11 +20,8 @@
 
 #include "Arduino.h"
 #include "api/HardwareSPI.h"
-#if !defined(ARDUINO_AS_MBED_LIBRARY)
-#include "drivers/SPIMaster.h"
-#else
-#include "drivers/SPI.h"
-#endif
+
+typedef struct _mbed_spi mbed_spi;
 
 namespace arduino {
 
@@ -51,7 +48,7 @@ public:
 
 private:
     SPISettings settings = SPISettings(0, MSBFIRST, SPI_MODE0);
-    mbed::SPI* dev;
+    _mbed_spi* dev;
     int _miso;
     int _mosi;
     int _sck;

--- a/libraries/ThreadDebug/src/ThreadDebug.h
+++ b/libraries/ThreadDebug/src/ThreadDebug.h
@@ -32,7 +32,10 @@
 #pragma once
 
 #include <Arduino.h>
-//#include <mbed.h>
+#ifdef SERIAL_CDC
+#include <USB/PluggableUSBSerial.h>
+#endif
+#include "mbed.h"
 
 #if defined(STM32H747xx) && defined(CORE_CM4)
 // include RPC out of arduino namespace

--- a/libraries/USBHOST/src/class/host/tusbh_mbed_os.cpp
+++ b/libraries/USBHOST/src/class/host/tusbh_mbed_os.cpp
@@ -40,6 +40,7 @@ extern "C" {
 #include <stdlib.h>
 
 #include "Arduino.h"
+#include "mbed.h"
 
 #ifdef TUSB_HAS_OS
 

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -21,6 +21,7 @@
 */
 
 #include "Wire.h"
+#include "pinDefinitions.h"
 
 arduino::MbedI2C::MbedI2C(int sda, int scl) : _sda(sda), _scl(scl), usedTxBuffer(0) {}
 

--- a/mbed-os-to-arduino
+++ b/mbed-os-to-arduino
@@ -337,7 +337,7 @@ done
 copy_core_files
 patch_mbed_h
 patch_spi_h
-patch_callback_h
+#patch_callback_h
 
 echo
 echo "[$(basename $0)] MbedOS core generation ended succesfully."

--- a/mbed-os-to-arduino
+++ b/mbed-os-to-arduino
@@ -230,6 +230,12 @@ patch_spi_h () {
 	echo " done."
 }
 
+patch_callback_h () {
+	echo -n "Patching Callback.h..."
+	sed -i 's|namespace mbed|#define F _F\nnamespace mbed|g' "$ARDUINOCOREMBED"/platform/Callback.h
+	echo " done."
+}
+
 #############
 # MAIN LOOP #
 #############
@@ -331,6 +337,7 @@ done
 copy_core_files
 patch_mbed_h
 patch_spi_h
+patch_callback_h
 
 echo
 echo "[$(basename $0)] MbedOS core generation ended succesfully."

--- a/variants/ARDUINO_NANO33BLE/pins_arduino.h
+++ b/variants/ARDUINO_NANO33BLE/pins_arduino.h
@@ -47,6 +47,8 @@ extern "C" unsigned int PINCOUNT_fn();
 #define NUM_ANALOG_INPUTS    (8u)
 #define NUM_ANALOG_OUTPUTS   (0u)
 
+extern PinName digitalPinToPinName(int P);
+
 // LEDs
 // ----
 #define PIN_LED     (13u)

--- a/variants/ARDUINO_NANO33BLE/pins_arduino.h
+++ b/variants/ARDUINO_NANO33BLE/pins_arduino.h
@@ -47,7 +47,7 @@ extern "C" unsigned int PINCOUNT_fn();
 #define NUM_ANALOG_INPUTS    (8u)
 #define NUM_ANALOG_OUTPUTS   (0u)
 
-extern PinName digitalPinToPinName(int P);
+extern PinName digitalPinToPinName(pin_size_t P);
 
 // LEDs
 // ----

--- a/variants/ARDUINO_NANO33BLE/variant.cpp
+++ b/variants/ARDUINO_NANO33BLE/variant.cpp
@@ -1,4 +1,5 @@
 #include "Arduino.h"
+#include "pinDefinitions.h"
 
 /* wiring_analog variables definition */
 /* Flag to indicate whether the ADC config has been changed from the default one */

--- a/variants/PORTENTA_H7_M4/pins_arduino.h
+++ b/variants/PORTENTA_H7_M4/pins_arduino.h
@@ -13,6 +13,8 @@ extern "C" bool isBetaBoard();
 #define NUM_ANALOG_INPUTS    (7u)
 #define NUM_ANALOG_OUTPUTS   (1u)
 
+extern PinName digitalPinToPinName(int P);
+
 // LEDs
 // ----
 #define PIN_LED     (23u)

--- a/variants/PORTENTA_H7_M4/pins_arduino.h
+++ b/variants/PORTENTA_H7_M4/pins_arduino.h
@@ -13,7 +13,7 @@ extern "C" bool isBetaBoard();
 #define NUM_ANALOG_INPUTS    (7u)
 #define NUM_ANALOG_OUTPUTS   (1u)
 
-extern PinName digitalPinToPinName(int P);
+extern PinName digitalPinToPinName(pin_size_t P);
 
 // LEDs
 // ----

--- a/variants/PORTENTA_H7_M4/variant.cpp
+++ b/variants/PORTENTA_H7_M4/variant.cpp
@@ -1,4 +1,5 @@
 #include "Arduino.h"
+#include "pinDefinitions.h"
 
 AnalogPinDescription g_AAnalogPinDescription[] = {
   { PA_0C,        NULL },    // A0    ADC2_INP0

--- a/variants/PORTENTA_H7_M7/pins_arduino.h
+++ b/variants/PORTENTA_H7_M7/pins_arduino.h
@@ -13,6 +13,8 @@ extern "C" bool isBetaBoard();
 // ----
 #define bootM4() LL_RCC_ForceCM4Boot() // Provide a memorable alias
 
+extern PinName digitalPinToPinName(int P);
+
 // Pin count
 // ----
 #define PINS_COUNT           (PINCOUNT_fn())

--- a/variants/PORTENTA_H7_M7/pins_arduino.h
+++ b/variants/PORTENTA_H7_M7/pins_arduino.h
@@ -13,7 +13,7 @@ extern "C" bool isBetaBoard();
 // ----
 #define bootM4() LL_RCC_ForceCM4Boot() // Provide a memorable alias
 
-extern PinName digitalPinToPinName(int P);
+extern PinName digitalPinToPinName(pin_size_t P);
 
 // Pin count
 // ----

--- a/variants/PORTENTA_H7_M7/variant.cpp
+++ b/variants/PORTENTA_H7_M7/variant.cpp
@@ -1,4 +1,5 @@
 #include "Arduino.h"
+#include "pinDefinitions.h"
 
 RTC_HandleTypeDef RTCHandle;
 


### PR DESCRIPTION
This rewrites complicates a bit the core stucture, while improving dramatically compile time.

To achieve this, we avoid including the most heavy headers (primarily `Callback.h` from `mbed.h`) in `Arduino.h` or any other "library" header. Since headers need to reference mbed classes, these are passed via opaque structures, at the cost of
a level of dereference.

Tests using a Windows10 VM with a single core @ 3.5GHz

Target: Portenta H7 M7

| Sketch  | Core 1.3.0 | This PR |
| ------------- | ------------- | ------------- |
| Cold cache - Arduino BLE  | 2'55" | 1'35" |
| Warm cache - Arduino BLE (precompiled core) | 2'15" | 47" |

Tests using a Windows10 VM with a quad core @ 3.5GHz

| Sketch  | Core 1.3.0 | This PR |
| ------------- | ------------- | ------------- |
| Cold cache - Arduino BLE  | 1'27" | 43" |
| Warm cache - Arduino BLE (precompiled core) | 56" | 26" |

