### PR TITLE
PluggableUSB: modules modify bcdDevice value

### DIFF
--- a/cores/arduino/USB/PluggableUSBDevice.cpp
+++ b/cores/arduino/USB/PluggableUSBDevice.cpp
@@ -95,6 +95,7 @@ bool arduino::PluggableUSBDevice::plug(internal::PluggableUSBModule*node)
 
     node->pluggedInterface = lastIf;
     lastIf += node->numInterfaces;
+    product_release += node->getProductVersion();
     return true;
 }
 

--- a/cores/arduino/USB/PluggableUSBDevice.h
+++ b/cores/arduino/USB/PluggableUSBDevice.h
@@ -58,6 +58,7 @@ protected:
     virtual void callback_set_interface(uint16_t interface, uint8_t alternate);
     virtual void init(EndpointResolver& resolver);
     virtual const uint8_t *string_iinterface_desc();
+    virtual uint8_t getProductVersion();
 
     uint8_t pluggedInterface;
 

--- a/cores/arduino/USB/USBCDC.cpp
+++ b/cores/arduino/USB/USBCDC.cpp
@@ -489,6 +489,11 @@ const uint8_t *USBCDC::string_iinterface_desc()
     return (const uint8_t *)extraDescriptor;
 }
 
+uint8_t USBCDC::getProductVersion()
+{
+    return 1;
+}
+
 const uint8_t *USBCDC::string_iproduct_desc()
 {
     static const uint8_t stringIproductDescriptor[] = {

--- a/cores/arduino/USB/USBCDC.h
+++ b/cores/arduino/USB/USBCDC.h
@@ -145,6 +145,13 @@ protected:
     virtual const uint8_t *string_iproduct_desc();
 
     /*
+    * Get string product version
+    *
+    * Every module must declare a different number
+    */
+    virtual uint8_t getProductVersion();
+
+    /*
     * Get string interface descriptor
     *
     * @returns pointer to the string interface descriptor

--- a/libraries/USBAudio/PluggableUSBAudio.h
+++ b/libraries/USBAudio/PluggableUSBAudio.h
@@ -274,6 +274,13 @@ protected:
     virtual const uint8_t *string_iinterface_desc();
     virtual const uint8_t *configuration_desc(uint8_t index);
 
+    /*
+    * Get string product version
+    *
+    * Every module must declare a different number
+    */
+    virtual uint8_t getProductVersion();
+
 private:
 
     class AsyncWrite;

--- a/libraries/USBAudio/USBAudio.cpp
+++ b/libraries/USBAudio/USBAudio.cpp
@@ -588,6 +588,11 @@ const uint8_t *USBAudio::configuration_desc(uint8_t index)
     return _config_descriptor;
 }
 
+uint8_t USBAudio::getProductVersion()
+{
+    return 2;
+}
+
 const uint8_t *USBAudio::string_iinterface_desc()
 {
     static const uint8_t stringIinterfaceDescriptor[] = {

--- a/libraries/USBHID/PluggableUSBHID.h
+++ b/libraries/USBHID/PluggableUSBHID.h
@@ -164,6 +164,13 @@ protected:
     virtual uint16_t report_desc_length();
 
     /*
+    * Get string product version
+    *
+    * Every module must declare a different number
+    */
+    virtual uint8_t getProductVersion();
+
+    /*
     * Get string product descriptor
     *
     * @returns pointer to the string product descriptor

--- a/libraries/USBHID/USBHID.cpp
+++ b/libraries/USBHID/USBHID.cpp
@@ -388,6 +388,10 @@ void USBHID::callback_set_interface(uint16_t interface, uint8_t alternate)
     assert_locked();
 }
 
+uint8_t USBHID::getProductVersion()
+{
+    return 4;
+}
 
 const uint8_t *USBHID::string_iinterface_desc()
 {

--- a/libraries/USBMSD/PluggableUSBMSD.h
+++ b/libraries/USBMSD/PluggableUSBMSD.h
@@ -282,6 +282,13 @@ private:
     // space for config descriptor
     uint8_t _configuration_descriptor[32];
 
+    /*
+    * Get string product version
+    *
+    * Every module must declare a different number
+    */
+    virtual uint8_t getProductVersion();
+
     virtual const uint8_t *string_iproduct_desc();
     virtual const uint8_t *string_iinterface_desc();
     virtual const uint8_t *configuration_desc(uint8_t index);

--- a/libraries/USBMSD/USBMSD.cpp
+++ b/libraries/USBMSD/USBMSD.cpp
@@ -311,6 +311,10 @@ void USBMSD::callback_set_interface(uint16_t interface, uint8_t alternate)
     //complete_set_interface(success);
 }
 
+uint8_t USBMSD::getProductVersion()
+{
+    return 8;
+}
 
 const uint8_t *USBMSD::string_iinterface_desc()
 {


### PR DESCRIPTION
This should solve driver mismatch in Windows when a different USBDevice functionality is added/removed.
Based on this suggestion: https://github.com/arduino-libraries/Keyboard/issues/41#issuecomment-730700142

Fixes https://github.com/arduino/ArduinoCore-mbed/issues/107#issuecomment-750378348