### PR TITLE
Use authenticated API requests in "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           fqbn: ${{ matrix.board.fqbn }}
           platforms: |
             # Use Board Manager to install the latest release of Arduino mbed Boards to get the toolchain


### PR DESCRIPTION
The arduino/compile-sketches GitHub Actions action used in the "Compile Examples" workflow queries the GitHub API for the base ref of the pull request, which is used for the memory deltas determination.

There were a couple workflow runs recently (1, 2) that failed due to rate limiting. Authenticated API requests are given a more generous API request allowance, so providing the action with the automatically generated GitHub access token should prevent this from happening again.