### PR TITLE
Enable SDMMC hardware Flow Control

### DIFF
--- a/libraries/Portenta_SDCARD/BSP.c
+++ b/libraries/Portenta_SDCARD/BSP.c
@@ -104,7 +104,7 @@ uint8_t BSP_SD_Init(void)
   uSdHandle.Init.ClockDiv            = 6;
   uSdHandle.Init.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
   uSdHandle.Init.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
-  uSdHandle.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
+  uSdHandle.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_ENABLE;
   uSdHandle.Init.BusWide             = SDMMC_BUS_WIDE_4B;
 
   /* Msp SD initialization */


### PR DESCRIPTION
This issue came out using SD as OTA storage method for Portenta ( [Arduino_Portenta_OTA #7](https://github.com/arduino-libraries/Arduino_Portenta_OTA/pull/7) ): data are fetched from an http server and written in a file in the SD card.
If SDMMC Hardware Flow Control is disabled, the download stops after few blocks of data are exchanged, due to an SD corruption.
The problem has been solved enabling the Flow Control.