### PR TITLE
include Arduino.h in Portenta_Camera/camera.h

### DIFF
--- a/libraries/Portenta_Camera/camera.h
+++ b/libraries/Portenta_Camera/camera.h
@@ -1,3 +1,5 @@
+#include "Arduino.h"
+
 enum {
     CAMERA_R160x120 = 0x00,   /* QQVGA Resolution */
     CAMERA_R320x240 = 0x01,   /* QVGA Resolution  */


### PR DESCRIPTION
Add include of Arduino.h in Portenta_Camera/camera.h to allow inclusion of camera.h in a .cpp file without having to explicitly include Arduino.h in the .cpp file