### PR TITLE
Fix buffer sync issue in camera raw bytes example

### DIFF
--- a/libraries/Portenta_Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
+++ b/libraries/Portenta_Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
@@ -4,8 +4,7 @@ CameraClass cam;
 uint8_t fb[320*240];
 
 void setup() {
-
-  Serial.begin(921600);
+  Serial.begin(921600);  
 
   // Init the cam QVGA, 30FPS
   cam.begin(CAMERA_R320x240, 30);
@@ -13,10 +12,14 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
-  if (Serial) {
-    // Grab frame and write to serial
-    if (cam.grab(fb) == 0) {
-       Serial.write(fb, 320*240);
-    }
+  
+  // Wait until the receiver acknowledges
+  // that they are ready to receive new data
+  while(Serial.read() != 1){};
+  
+  // Grab frame and write to serial
+  if (cam.grab(fb) == 0) {
+     Serial.write(fb, 320*240);       
   }
+  
 }

--- a/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
+++ b/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
@@ -21,6 +21,7 @@ final int bytesPerFrame = cameraPixelCount * cameraBytesPerPixel;
 
 PImage myImage;
 byte[] frameBuffer = new byte[bytesPerFrame];
+int lastUpdate = 0;
 
 void setup() {
   size(640, 480);
@@ -46,9 +47,16 @@ void draw() {
   PImage img = myImage.copy();
   img.resize(640, 480);
   image(img, 0, 0);
+  // Time out after 1.5 seconds and ask for new data
+  if(millis() - lastUpdate > 1500) {
+    println("Connection timed out.");
+    myPort.write(1);
+  }
 }
 
 void serialEvent(Serial myPort) {
+  lastUpdate = millis();
+  
   // read the received bytes
   myPort.readBytes(frameBuffer);
 

--- a/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
+++ b/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
@@ -27,12 +27,12 @@ void setup()
   size(640, 480);
 
   // if you have only ONE serial port active
-  //myPort = new Serial(this, Serial.list()[0], 9600);          // if you have only ONE serial port active
+  //myPort = new Serial(this, Serial.list()[0], 921600);          // if you have only ONE serial port active
 
   // if you know the serial port name
-  //myPort = new Serial(this, "COM5", 9600);                    // Windows
+  //myPort = new Serial(this, "COM5", 921600);                    // Windows
   //myPort = new Serial(this, "/dev/ttyACM0", 921600);            // Linux
-  myPort = new Serial(this, "/dev/cu.usbmodem14401", 9600);     // Mac
+  myPort = new Serial(this, "/dev/cu.usbmodem14401", 921600);     // Mac
 
   // wait for full frame of bytes
   myPort.buffer(bytesPerFrame);  

--- a/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
+++ b/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
@@ -22,8 +22,7 @@ final int bytesPerFrame = cameraPixelCount * cameraBytesPerPixel;
 PImage myImage;
 byte[] frameBuffer = new byte[bytesPerFrame];
 
-void setup()
-{
+void setup() {
   size(640, 480);
 
   // if you have only ONE serial port active
@@ -43,15 +42,14 @@ void setup()
   myPort.write(1);
 }
 
-void draw()
-{
+void draw() {
   PImage img = myImage.copy();
   img.resize(640, 480);
   image(img, 0, 0);
 }
 
 void serialEvent(Serial myPort) {
-  // read the saw bytes in
+  // read the received bytes
   myPort.readBytes(frameBuffer);
 
   // access raw bytes via byte buffer
@@ -62,17 +60,14 @@ void serialEvent(Serial myPort) {
 
   while (bb.hasRemaining()) {
     // read 16-bit pixel
-    byte p = bb.get();
-
+    byte pixelValue = bb.get();
 
     // set pixel color
-    myImage .pixels[i++] = color(Byte.toUnsignedInt(p));
-    
-    // Let the Arduino sketch know we received all pixels
-    // and are ready for the next frame
-    if(i == cameraPixelCount){
-      myPort.write(1);
-    }
+    myImage.pixels[i++] = color(Byte.toUnsignedInt(pixelValue));    
   }
+  
   myImage.updatePixels();
+  // Let the Arduino sketch know we received all pixels
+  // and are ready for the next frame
+  myPort.write(1);
 }

--- a/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
+++ b/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
@@ -48,6 +48,7 @@ void draw() {
   // Time out after 1.5 seconds and ask for new data
   if(millis() - lastUpdate > 1500) {
     println("Connection timed out.");
+    myPort.clear();
     myPort.write(1);
   }
   

--- a/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
+++ b/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
@@ -16,7 +16,8 @@ Serial myPort;
 final int cameraWidth = 320;
 final int cameraHeight = 240;
 final int cameraBytesPerPixel = 1;
-final int bytesPerFrame = cameraWidth * cameraHeight * cameraBytesPerPixel;
+final int cameraPixelCount = cameraWidth * cameraHeight;
+final int bytesPerFrame = cameraPixelCount * cameraBytesPerPixel;
 
 PImage myImage;
 byte[] frameBuffer = new byte[bytesPerFrame];
@@ -30,13 +31,16 @@ void setup()
 
   // if you know the serial port name
   //myPort = new Serial(this, "COM5", 9600);                    // Windows
-  myPort = new Serial(this, "/dev/ttyACM0", 921600);            // Linux
-  //myPort = new Serial(this, "/dev/cu.usbmodem14401", 9600);     // Mac
+  //myPort = new Serial(this, "/dev/ttyACM0", 921600);            // Linux
+  myPort = new Serial(this, "/dev/cu.usbmodem14401", 9600);     // Mac
 
   // wait for full frame of bytes
   myPort.buffer(bytesPerFrame);  
 
   myImage = createImage(cameraWidth, cameraHeight, ALPHA);
+  
+  // Let the Arduino sketch know we're ready to receive data
+  myPort.write(1);
 }
 
 void draw()
@@ -63,7 +67,12 @@ void serialEvent(Serial myPort) {
 
     // set pixel color
     myImage .pixels[i++] = color(Byte.toUnsignedInt(p));
+    
+    // Let the Arduino sketch know we received all pixels
+    // and are ready for the next frame
+    if(i == cameraPixelCount){
+      myPort.write(1);
+    }
   }
- myImage.updatePixels();
-
+  myImage.updatePixels();
 }

--- a/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
+++ b/libraries/Portenta_Camera/extras/CameraRawBytesVisualizer/CameraRawBytesVisualizer.pde
@@ -66,10 +66,15 @@ void serialEvent(Serial myPort) {
   // read the received bytes
   myPort.readBytes(frameBuffer);
 
-  // Access raw bytes via byte buffer and ensure
-  // proper endianness of the data for > 8 bit values.
+  // Access raw bytes via byte buffer  
   ByteBuffer bb = ByteBuffer.wrap(frameBuffer);
-  bb.order(ByteOrder.BIG_ENDIAN);
+  
+  /* 
+    Ensure proper endianness of the data for > 8 bit values.
+    When using > 8bit values uncomment the following line and
+    adjust the translation to the pixel color. 
+  */     
+  //bb.order(ByteOrder.BIG_ENDIAN);
 
   int i = 0;
 


### PR DESCRIPTION
Adds a very basic synchronization to the Arduino and Processing sketch to make sure the buffer doesn't get out of sync.
Here is the before / after comparison:

<img width="640" alt="Before" src="https://user-images.githubusercontent.com/1326220/108702493-a21e9200-7509-11eb-8f6b-a8ecab56b6dd.png">

<img width="640" alt="After" src="https://user-images.githubusercontent.com/1326220/108702501-a5198280-7509-11eb-8e70-7f16303d5cf6.png">