### PR TITLE
Camera API Improvements

### DIFF
--- a/libraries/Portenta_Camera/camera.cpp
+++ b/libraries/Portenta_Camera/camera.cpp
@@ -500,7 +500,7 @@ int CameraClass::framerate(uint32_t framerate)
 int CameraClass::grab(uint8_t *buffer, uint32_t timeout)
 {
   if (this->initialized == false) {
-    return -1;
+    return false;
   }
 
   BSP_CAMERA_Resume();
@@ -518,7 +518,7 @@ int CameraClass::grab(uint8_t *buffer, uint32_t timeout)
     __WFI();
     if ((millis() - start) > timeout) {
       HAL_DMA_Abort(hdcmi_discovery.DMA_Handle);
-      return -1;
+      return false;
     }
   }
 
@@ -529,7 +529,7 @@ int CameraClass::grab(uint8_t *buffer, uint32_t timeout)
   /* Invalidate buffer after DMA transfer */
   SCB_InvalidateDCache_by_Addr((uint32_t*)buffer, framesize);
 
-  return 0;
+  return true;
 }
 
 int CameraClass::standby(bool enable)

--- a/libraries/Portenta_Camera/camera.cpp
+++ b/libraries/Portenta_Camera/camera.cpp
@@ -497,7 +497,7 @@ int CameraClass::framerate(uint32_t framerate)
   return HIMAX_SetFramerate(framerate);
 }
 
-int CameraClass::grab(uint8_t *buffer, uint32_t timeout)
+bool CameraClass::grab(uint8_t *buffer, uint32_t timeout)
 {
   if (this->initialized == false) {
     return false;

--- a/libraries/Portenta_Camera/camera.h
+++ b/libraries/Portenta_Camera/camera.h
@@ -16,7 +16,7 @@ class CameraClass {
         CameraClass(): initialized(false), md_irq(PC_15){}
         int begin(uint32_t resolution = CAMERA_R320x240, uint32_t framerate = 30);
         int framerate(uint32_t framerate);
-        int grab(uint8_t *buffer, uint32_t timeout=5000);
+        bool grab(uint8_t *buffer, uint32_t timeout=5000);
         int standby(bool enable);
         int motionDetection(bool enable, md_callback_t callback=NULL);
         int motionDetectionWindow(uint32_t x, uint32_t y, uint32_t w, uint32_t h);

--- a/libraries/Portenta_Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
+++ b/libraries/Portenta_Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
@@ -1,7 +1,7 @@
 #include "camera.h"
 
 CameraClass cam;
-uint8_t fb[320*240];
+uint8_t frameBuffer[320*240];
 
 void setup() {
 
@@ -15,8 +15,8 @@ void loop() {
   // put your main code here, to run repeatedly:
   if (Serial) {
     // Grab frame and write to serial
-    if (cam.grab(fb) == 0) {
-       Serial.write(fb, 320*240);
+    if (cam.grab(frameBuffer)) {
+       Serial.write(frameBuffer, 320*240);
     }
   }
 }

--- a/libraries/Portenta_Camera/examples/CameraMotionDetect/CameraMotionDetect.ino
+++ b/libraries/Portenta_Camera/examples/CameraMotionDetect/CameraMotionDetect.ino
@@ -1,7 +1,6 @@
 #include "camera.h"
 
 CameraClass cam;
-uint8_t fb[320*240];
 bool motion_detected = false;
 
 void on_motion()

--- a/libraries/Portenta_Camera/examples/CameraMotionDetect/CameraMotionDetect.ino
+++ b/libraries/Portenta_Camera/examples/CameraMotionDetect/CameraMotionDetect.ino
@@ -1,11 +1,10 @@
 #include "camera.h"
 
 CameraClass cam;
-bool motion_detected = false;
+bool motionDetected = false;
 
-void on_motion()
-{
-  motion_detected = true;
+void onMotion() {
+  motionDetected = true;
 }
 
 void setup() {
@@ -20,19 +19,19 @@ void setup() {
   cam.motionDetectionThreshold(100, 200);
   cam.motionDetectionWindow(0, 0, 320, 240);
   // The detection can also be enabled without any callback
-  cam.motionDetection(true, on_motion);
+  cam.motionDetection(true, onMotion);
 }
 
 void loop() {
 
-  if (motion_detected) {
+  if (motionDetected) {
     Serial.printf("Motion Detected!\n");
     digitalWrite(LEDB, LOW);
     delay(500);
 
     // Clear the detection flag
     cam.motionDetected();
-    motion_detected = false;
+    motionDetected = false;
     digitalWrite(LEDB, HIGH);
   }
   delay(10);


### PR DESCRIPTION
As discussed with @Lenardgeorge it's a bit counter intuitive for non Unix people to use `0` as a success return value. We've traditionally used either a boolean or a numeric value that has semantically correct type coercion to bool.
In this case I'd go with a boolean unless we've planned on adding more elaborate error codes for that function.

Secondly the variables and function names in the motion detection examples were changed to camel case which is the default for Arduino example code.