### PR TITLE
Add A7 pin identifier

### DIFF
--- a/variants/PORTENTA_H7_M7/pins_arduino.h
+++ b/variants/PORTENTA_H7_M7/pins_arduino.h
@@ -37,6 +37,8 @@ extern "C" bool isBetaBoard();
 #define PIN_A4 (19u)
 #define PIN_A5 (20u)
 #define PIN_A6 (21u)
+#define PIN_A7 (22u)
+
 static const uint8_t A0  = PIN_A0;
 static const uint8_t A1  = PIN_A1;
 static const uint8_t A2  = PIN_A2;
@@ -44,6 +46,7 @@ static const uint8_t A3  = PIN_A3;
 static const uint8_t A4  = PIN_A4;
 static const uint8_t A5  = PIN_A5;
 static const uint8_t A6  = PIN_A6;
+static const uint8_t A7  = PIN_A7;
 #define ADC_RESOLUTION 12
 
 //DACs

--- a/variants/PORTENTA_H7_M7/variant.cpp
+++ b/variants/PORTENTA_H7_M7/variant.cpp
@@ -9,7 +9,8 @@ AnalogPinDescription g_AAnalogPinDescription[] = {
   { PC_3C,        NULL },    // A3    ADC3_INP1
   { PC_2_ALT0,    NULL },    // A4    ADC1_INP12
   { PC_3_ALT2,    NULL },    // A5    ADC2_INP13
-  { PA_4,         NULL }     // A6    ADC1_INP18
+  { PA_4,         NULL },    // A6    ADC1_INP18
+  { PA_6,         NULL }     // A7    ADC1_INP7
 };
 
 PinDescription g_APinDescription[] = {
@@ -40,6 +41,7 @@ PinDescription g_APinDescription[] = {
   { PC_2_ALT0,    NULL, NULL, NULL },    // A4    ADC1_INP12
   { PC_3_ALT0,    NULL, NULL, NULL },    // A5    ADC1_INP13
   { PA_4,         NULL, NULL, NULL },    // A6    ADC1_INP18
+  { PA_6,         NULL, NULL, NULL },    // A7    ADC1_INP7
 
   // LEDS
   { PK_5,         NULL, NULL, NULL },    // LEDR


### PR DESCRIPTION
Adds the missing A7 pin identifier to be used in Arduino sketches.