### PR TITLE
fix: address warnings

### DIFF
--- a/cores/arduino/USB/USBCDC.cpp
+++ b/cores/arduino/USB/USBCDC.cpp
@@ -540,7 +540,7 @@ const uint8_t *USBCDC::configuration_desc(uint8_t index)
         0x02,                   // bInterfaceClass
         0x02,                   // bInterfaceSubClass
         0x01,                   // bInterfaceProtocol
-        (extraDescriptor != NULL) ? 0x5 : 0x0, // iInterface
+        static_cast<uint8_t>((extraDescriptor != NULL) ? 0x5 : 0x0), // iInterface
 
         // CDC Header Functional Descriptor, CDC Spec 5.2.3.1, Table 26
         5,                      // bFunctionLength

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -138,8 +138,8 @@ void arduino::MbedI2C::receiveThd() {
 				rxBuffer.clear();
 				char buf[16];
 				while (1) {
-					int c = slave->read(buf, sizeof(buf));
-					for (int i = 0; i < c; i++) {
+					size_t c = slave->read(buf, sizeof(buf));
+					for (size_t i = 0; i < c; i++) {
 						rxBuffer.store_char(uint8_t(buf[i]));
 					}
 					if (c <= sizeof(buf)) {


### PR DESCRIPTION
Addresses type warnings in `Wire.cpp` and `USBCDC.cpp`