### PR TITLE
Match Portenta to Nano 33 BLE Digital Pins format

### DIFF
--- a/variants/ARDUINO_NANO33BLE/pins_arduino.h
+++ b/variants/ARDUINO_NANO33BLE/pins_arduino.h
@@ -78,20 +78,20 @@ static const uint8_t A7  = PIN_A7;
 
 // Digital pins
 // -----------
-#define D0   0
-#define D1   1
-#define D2   2
-#define D3   3
-#define D4   4
-#define D5   5
-#define D6   6
-#define D7   7
-#define D8   8
-#define D9   9
-#define D10  10
-#define D11  11
-#define D12  12
-#define D13  13
+#define D0  (0u)
+#define D1  (1u)
+#define D2  (2u)
+#define D3  (3u)
+#define D4  (4u)
+#define D5  (5u)
+#define D6  (6u)
+#define D7  (7u)
+#define D8  (8u)
+#define D9  (9u)
+#define D10 (10u)
+#define D11 (11u)
+#define D12 (12u)
+#define D13 (13u)
 
 /*
  * Serial interfaces

--- a/variants/PORTENTA_H7_M4/pins_arduino.h
+++ b/variants/PORTENTA_H7_M4/pins_arduino.h
@@ -39,6 +39,31 @@ static const uint8_t A5  = PIN_A5;
 static const uint8_t A6  = PIN_A6;
 #define ADC_RESOLUTION 12
 
+// Digital pins
+// -----------
+#define D0  (0u)
+#define D1  (1u)
+#define D2  (2u)
+#define D3  (3u)
+#define D4  (4u)
+#define D5  (5u)
+#define D6  (6u)
+#define D7  (7u)
+#define D8  (8u)
+#define D9  (9u)
+#define D10 (10u)
+#define D11 (11u)
+#define D12 (12u)
+#define D13 (13u)
+#define D14 (14u)
+#define D15 (15u)
+#define D16 (u16)
+#define D17 (u17)
+#define D18 (u18)
+#define D19 (u19)
+#define D20 (u20)
+#define D21 (u21)
+
 //DACs
 #define DAC           (A6)
 

--- a/variants/PORTENTA_H7_M7/pins_arduino.h
+++ b/variants/PORTENTA_H7_M7/pins_arduino.h
@@ -46,6 +46,31 @@ static const uint8_t A5  = PIN_A5;
 static const uint8_t A6  = PIN_A6;
 #define ADC_RESOLUTION 12
 
+// Digital pins
+// -----------
+#define D0  (0u)
+#define D1  (1u)
+#define D2  (2u)
+#define D3  (3u)
+#define D4  (4u)
+#define D5  (5u)
+#define D6  (6u)
+#define D7  (7u)
+#define D8  (8u)
+#define D9  (9u)
+#define D10 (10u)
+#define D11 (11u)
+#define D12 (12u)
+#define D13 (13u)
+#define D14 (14u)
+#define D15 (15u)
+#define D16 (u16)
+#define D17 (u17)
+#define D18 (u18)
+#define D19 (u19)
+#define D20 (u20)
+#define D21 (u21)
+
 //DACs
 #define DAC           (A6)
 


### PR DESCRIPTION
The Nano 33 BLE pins_arduino.h file has the digital pins defined as they are marked on the board pin-out diagram.

This PR adds that ability to both cores of the PortentaH7.

Also corrects the format of adding the pin defines for all boards.

  
Was   ------->    Now
```
#define D12 12       ------>     #define D12 (12u) 
```