### PR TITLE
Update GitHub Actions actions used in sketch compilation CI workflows

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -24,7 +24,8 @@ jobs:
 
     env:
       # sketch paths to compile (recursive) compatible with all boards
-      UNIVERSAL_SKETCH_PATHS: '"libraries/Scheduler"'
+      UNIVERSAL_SKETCH_PATHS: |
+        - libraries/Scheduler
       SKETCHES_REPORTS_PATH: sketches-reports
 
     strategy:
@@ -40,13 +41,27 @@ jobs:
         include:
           - board:
               fqbn: arduino:mbed:nano33ble
-            additional-sketch-paths: '"libraries/PDM" "libraries/ThreadDebug"'
+            additional-sketch-paths: |
+              - libraries/PDM
+              - libraries/ThreadDebug
           - board:
               fqbn: arduino:mbed:envie_m4
-            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_Video"'
+            additional-sketch-paths: |
+              - libraries/doom
+              - libraries/KernelDebug
+              - libraries/Portenta_SDCARD
+              - libraries/Portenta_Video
           - board:
               fqbn: arduino:mbed:envie_m7
-            additional-sketch-paths: '"libraries/doom" "libraries/KernelDebug" "libraries/Portenta_SDCARD" "libraries/Portenta_System" "libraries/Portenta_Video" "libraries/ThreadDebug" "libraries/USBHOST" "libraries/WiFi"'
+            additional-sketch-paths: |
+              - libraries/doom
+              - libraries/KernelDebug
+              - libraries/Portenta_SDCARD
+              - libraries/Portenta_System
+              - libraries/Portenta_Video
+              - libraries/ThreadDebug
+              - libraries/USBHOST
+              - libraries/WiFi
 
     steps:
       - name: Checkout repository
@@ -73,9 +88,11 @@ jobs:
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "arduino:mbed"
-          sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
+          sketch-paths: |
+            ${{ env.UNIVERSAL_SKETCH_PATHS }}
+            ${{ matrix.additional-sketch-paths }}
           verbose: 'false'
-          enable-size-deltas-report: true
+          enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -76,6 +76,7 @@ jobs:
           sketch-paths: "${{ env.UNIVERSAL_SKETCH_PATHS }} ${{ matrix.additional-sketch-paths }}"
           verbose: 'false'
           enable-size-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       # sketch paths to compile (recursive) compatible with all boards
       UNIVERSAL_SKETCH_PATHS: '"libraries/Scheduler"'
+      SKETCHES_REPORTS_PATH: sketches-reports
 
     strategy:
       fail-fast: false
@@ -62,7 +63,7 @@ jobs:
         run: mv "$GITHUB_WORKSPACE/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"   
 
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: arduino/compile-sketches@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fqbn: ${{ matrix.board.fqbn }}
@@ -78,7 +79,7 @@ jobs:
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: size-deltas-reports
-          path: size-deltas-reports
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -8,4 +8,4 @@ jobs:
 
     steps:
       - name: Comment size deltas reports to PRs
-        uses: arduino/actions/libraries/report-size-deltas@master
+        uses: arduino/report-size-deltas@main

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -9,3 +9,6 @@ jobs:
     steps:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@main
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports


### PR DESCRIPTION
The "smoke test" sketch compilation and reporting actions have been moved to dedicated repositories. The actions hosted
at the old `arduino/actions/libraries/*` location will no longer be maintained.

Since the time the actions were migrated to the dedicated repositories, a breaking change was made to the default value of the `sketches-report-path` input, which required a change to the values of the `name` and `path` inputs of the `actions/upload-artifact` action.