### PR TITLE
Fix incorrect signature of overloaded function

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -73,7 +73,7 @@ uint8_t arduino::MbedI2C::endTransmission(void) {
 	return endTransmission(true);
 }
 
-size_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len, bool stopBit) {
+uint8_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len, bool stopBit) {
 	char buf[256];
 	int ret = master->read(address << 1, buf, len, !stopBit);
 	if (ret != 0) {
@@ -85,7 +85,7 @@ size_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len, bool stopBit) 
 	return len;
 }
 
-size_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len) {
+uint8_t arduino::MbedI2C::requestFrom(uint8_t address, size_t len) {
 	return requestFrom(address, len, true);
 }
 

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -49,8 +49,8 @@ class MbedI2C : public HardwareI2C
     virtual uint8_t endTransmission(bool stopBit);
     virtual uint8_t endTransmission(void);
 
-    virtual size_t requestFrom(uint8_t address, size_t len, bool stopBit);
-    virtual size_t requestFrom(uint8_t address, size_t len);
+    virtual uint8_t requestFrom(uint8_t address, size_t len, bool stopBit);
+    virtual uint8_t requestFrom(uint8_t address, size_t len);
 
     virtual void onReceive(void(*)(int));
     virtual void onRequest(void(*)(void));


### PR DESCRIPTION
This PR fixes a compiler error in `Wire.h` / `Wire.cpp` where an incorrect signature was used for the overloaded function `requestFrom`.

The compiler throws the following error:
```
error: conflicting return type specified for 'virtual size_t arduino::MbedI2C::requestFrom(uint8_t, size_t)'
     virtual size_t requestFrom(uint8_t address, size_t len);
```

`size_t` was used instead of `uint8_t`