### PR TITLE
Use major version refs of sketch compilation actions

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -87,7 +87,7 @@ jobs:
         run: mv "$GITHUB_WORKSPACE/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino"   
 
       - name: Compile examples
-        uses: arduino/compile-sketches@main
+        uses: arduino/compile-sketches@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fqbn: ${{ matrix.board.fqbn }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Comment size deltas reports to PRs
-        uses: arduino/report-size-deltas@main
+        uses: arduino/report-size-deltas@v1
         with:
           # The name of the workflow artifact created by the sketch compilation workflow
           sketches-reports-source: sketches-reports


### PR DESCRIPTION
Previously, due to the lack of a release, the development versions of the sketch compilation actions were used. Using release versions provides a more stable CI system for the ArduinoCore-mbed project.

Use of the major version ref will cause the workflow to benefit from ongoing development to the actions up until such time as a new major release of an action is made, at which time we would need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before updating the major ref (e.g., `uses: arduino/compile-sketches@v2`).