### PR TITLE
PDM.setBufferSize()

### DIFF
--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -42,6 +42,7 @@ public:
   //NANO 33 BLE SENSe min 0 max 80
   void setGain(int gain);
   void setBufferSize(int bufferSize);
+  size_t getBufferSize();
 
 // private:
   void IrqHandler(bool halftranfer);

--- a/libraries/PDM/src/stm32/PDM.cpp
+++ b/libraries/PDM/src/stm32/PDM.cpp
@@ -114,6 +114,11 @@ void PDMClass::setBufferSize(int bufferSize)
   _doubleBuffer.setSize(bufferSize);
 }
 
+size_t PDMClass::getBufferSize()
+{
+  return _doubleBuffer.getSize();
+}
+
 void PDMClass::IrqHandler(bool halftranfer)
 {
   if (_doubleBuffer.available() == 0) {
@@ -135,6 +140,10 @@ void PDMIrqHandler(bool halftranfer)
 
 void PDMsetBufferSize(int size) {
   PDM.setBufferSize(size);
+}
+
+size_t PDMgetBufferSize() {
+  return PDM.getBufferSize();
 }
 }
 

--- a/libraries/PDM/src/stm32/audio.c
+++ b/libraries/PDM/src/stm32/audio.c
@@ -303,8 +303,11 @@ int py_audio_init(size_t channels, uint32_t frequency, int gain_db, float highpa
         PDM_Filter_setConfig(&PDM_FilterHandler[i], &PDM_FilterConfig[i]);
     }
 
-    PDMsetBufferSize(samples_per_channel * g_o_channels * sizeof(int16_t));
-    //g_pcmbuf = malloc(samples_per_channel * g_channels * sizeof(int16_t));
+    uint32_t min_buff_size = samples_per_channel * g_o_channels * sizeof(int16_t);
+    uint32_t buff_size = PDMgetBufferSize();
+    if(buff_size < min_buff_size) {
+      PDMsetBufferSize(min_buff_size);
+    }
 
     return 1;
 }

--- a/libraries/PDM/src/utility/PDMDoubleBuffer.cpp
+++ b/libraries/PDM/src/utility/PDMDoubleBuffer.cpp
@@ -37,6 +37,11 @@ void PDMDoubleBuffer::setSize(int size)
   reset();
 }
 
+size_t PDMDoubleBuffer::getSize()
+{
+  return _size;
+}
+
 void PDMDoubleBuffer::reset()
 {
   _buffer[0] = (uint8_t*)realloc(_buffer[0], _size);

--- a/libraries/PDM/src/utility/PDMDoubleBuffer.h
+++ b/libraries/PDM/src/utility/PDMDoubleBuffer.h
@@ -31,6 +31,7 @@ public:
   virtual ~PDMDoubleBuffer();
 
   void setSize(int size);
+  size_t getSize();
 
   void reset();
 


### PR DESCRIPTION
this fixes #136 I don't like to much HALF_TRANSFER_SIZE define usage but i'm still thinking about it, maybe move the pointer update inside audio_pendsv_callback is the best option.

@rajames could you plese check if it works also in your environment?