### PR TITLE
PDM breakout

### DIFF
--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -59,7 +59,7 @@ private:
   int _init;
 
   PDMDoubleBuffer _doubleBuffer;
-  
+
   void (*_onReceive)(void);
 };
 

--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -42,6 +42,7 @@ public:
   //NANO 33 BLE SENSe min 0 max 80
   void setGain(int gain);
   void setBufferSize(int bufferSize);
+  size_t getBufferSize();
 
 // private:
   void IrqHandler(bool halftranfer);

--- a/libraries/PDM/src/stm32/PDM.cpp
+++ b/libraries/PDM/src/stm32/PDM.cpp
@@ -105,6 +105,9 @@ int PDMClass::read(void* buffer, size_t size)
 void PDMClass::onReceive(void(*function)(void))
 {
   _onReceive = function;
+  if(_instance != this) {
+    _instance = this;
+  }
 }
 
 void PDMClass::setGain(int gain)

--- a/libraries/PDM/src/stm32/PDM.cpp
+++ b/libraries/PDM/src/stm32/PDM.cpp
@@ -114,6 +114,11 @@ void PDMClass::setBufferSize(int bufferSize)
   _doubleBuffer.setSize(bufferSize);
 }
 
+size_t PDMClass::getBufferSize()
+{
+  return _doubleBuffer.getSize();
+}
+
 void PDMClass::IrqHandler(bool halftranfer)
 {
   if (_doubleBuffer.available() == 0) {
@@ -135,6 +140,10 @@ void PDMIrqHandler(bool halftranfer)
 
 void PDMsetBufferSize(int size) {
   PDM.setBufferSize(size);
+}
+
+size_t PDMgetBufferSize() {
+  return PDM.getBufferSize();
 }
 }
 

--- a/libraries/PDM/src/stm32/PDM.cpp
+++ b/libraries/PDM/src/stm32/PDM.cpp
@@ -66,6 +66,10 @@ int PDMClass::begin(int channels, int sampleRate) {
     i2c.write(8 << 1, data, sizeof(data));
   }
 
+  if(_instance != this) {
+    return 0;
+  }
+
   _channels = channels;
   _samplerate = sampleRate;
 

--- a/libraries/PDM/src/stm32/PDM.cpp
+++ b/libraries/PDM/src/stm32/PDM.cpp
@@ -29,6 +29,7 @@ extern "C" {
 }
 
 extern "C" uint16_t *g_pcmbuf;
+static PDMClass *_instance = NULL;
 
 PDMClass::PDMClass(int dinPin, int clkPin, int pwrPin) :
   _dinPin(dinPin),
@@ -40,10 +41,12 @@ PDMClass::PDMClass(int dinPin, int clkPin, int pwrPin) :
   _samplerate(-1),
   _init(-1)
 {
+  _instance = this;
 }
 
 PDMClass::~PDMClass()
 {
+  _instance = NULL;
 }
 
 int PDMClass::begin(int channels, int sampleRate) {
@@ -146,15 +149,15 @@ void PDMClass::IrqHandler(bool halftranfer)
 extern "C" {
 void PDMIrqHandler(bool halftranfer)
 {
-  PDM.IrqHandler(halftranfer);
+  _instance->IrqHandler(halftranfer);
 }
 
 void PDMsetBufferSize(int size) {
-  PDM.setBufferSize(size);
+  _instance->setBufferSize(size);
 }
 
 size_t PDMgetBufferSize() {
-  return PDM.getBufferSize();
+  return _instance.getBufferSize();
 }
 }
 

--- a/libraries/PDM/src/stm32/audio.c
+++ b/libraries/PDM/src/stm32/audio.c
@@ -303,8 +303,11 @@ int py_audio_init(size_t channels, uint32_t frequency, int gain_db, float highpa
         PDM_Filter_setConfig(&PDM_FilterHandler[i], &PDM_FilterConfig[i]);
     }
 
-    PDMsetBufferSize(samples_per_channel * g_o_channels * sizeof(int16_t));
-    //g_pcmbuf = malloc(samples_per_channel * g_channels * sizeof(int16_t));
+    uint32_t min_buff_size = samples_per_channel * g_o_channels * sizeof(int16_t);
+    uint32_t buff_size = PDMgetBufferSize();
+    if(buff_size < min_buff_size) {
+      PDMsetBufferSize(min_buff_size);
+    }
 
     return 1;
 }

--- a/libraries/PDM/src/utility/PDMDoubleBuffer.cpp
+++ b/libraries/PDM/src/utility/PDMDoubleBuffer.cpp
@@ -37,6 +37,11 @@ void PDMDoubleBuffer::setSize(int size)
   reset();
 }
 
+size_t PDMDoubleBuffer::getSize()
+{
+  return _size;
+}
+
 void PDMDoubleBuffer::reset()
 {
   _buffer[0] = (uint8_t*)realloc(_buffer[0], _size);

--- a/libraries/PDM/src/utility/PDMDoubleBuffer.h
+++ b/libraries/PDM/src/utility/PDMDoubleBuffer.h
@@ -31,6 +31,7 @@ public:
   virtual ~PDMDoubleBuffer();
 
   void setSize(int size);
+  size_t getSize();
 
   void reset();
 


### PR DESCRIPTION
Portenta has only one PDM peripheral. PDM is instanciated by default in the core, to allow PDM usage from breakout we need to store the correct _instance value.

_instance is initialized in the constructor and then updated when onReceive is called from user sketch.