### PR TITLE
Correct quoting in command used to set platform.txt version value

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -64,7 +64,7 @@ mv _bootloaders bootloaders
 
 #Patch title in platform.txt
 sed -i "s/Arduino Mbed OS Boards/Arduino Mbed OS ${FLAVOUR^} Boards/g" platform.txt
-sed -i 's/9.9.9/$VERSION/g' platform.txt
+sed -i "s/9.9.9/$VERSION/g" platform.txt
 
 BASE_FOLDER=`basename $PWD`
 


### PR DESCRIPTION
Single quotes caused what was intended to be a reference to the `VERSION` variable to instead be a string, resulting in the value of the platform.txt version property being set to "$VERSION":
```
version=$VERSION
```