### PR TITLE
Wire: fix "Arduino way" I2C scan

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -67,6 +67,14 @@ void arduino::MbedI2C::beginTransmission(uint8_t address) {
 }
 
 uint8_t arduino::MbedI2C::endTransmission(bool stopBit) {
+	#ifndef TARGET_PORTENTA_H7
+	if (usedTxBuffer == 0) {
+		// we are scanning, return 0 if the addresed device responds with an ACK
+		char buf[1];
+		int ret = master->read(_address, buf, 1, !stopBit);
+		return ret;
+	}
+	#endif
 	if (master->write(_address, (const char *) txBuffer, usedTxBuffer, !stopBit) == 0) return 0;
 	return 2;
 }


### PR DESCRIPTION
@sievers 
Completely fixes https://github.com/arduino/ArduinoCore-mbed/issues/212

Portenta is a bit peculiar and responds correctly to the zero bytes write() but not to the read(); to be investigated.