### PR TITLE
RP2040: avoid implicit conversion from NinaPin to int

### DIFF
--- a/cores/arduino/wiring_analog.cpp
+++ b/cores/arduino/wiring_analog.cpp
@@ -136,3 +136,8 @@ void analogReadResolution(int bits)
 {
   read_resolution = bits;
 }
+
+int getAnalogReadResolution()
+{
+  return read_resolution;
+}

--- a/variants/NANO_RP2040_CONNECT/nina_pins.cpp
+++ b/variants/NANO_RP2040_CONNECT/nina_pins.cpp
@@ -1,0 +1,9 @@
+#include "nina_pins.h"
+
+NinaPin  LEDR(27);
+NinaPin  LEDG(25);
+NinaPin  LEDB(26);
+NinaPin  A4(34);
+NinaPin  A5(39);
+NinaPin  A6(36);
+NinaPin  A7(35);

--- a/variants/NANO_RP2040_CONNECT/nina_pins.h
+++ b/variants/NANO_RP2040_CONNECT/nina_pins.h
@@ -21,15 +21,35 @@
  * TYPEDEF
  ******************************************************************************/
 
-enum NinaPin {
-  LEDR = 27,
-  LEDG = 25,
-  LEDB = 26,
-  A4   = 34,
-  A5   = 39,
-  A6   = 36,
-  A7   = 35
+int getAnalogReadResolution();
+
+class NinaPin {
+public:
+	NinaPin(int _pin) : pin(_pin) {};
+	int get() {
+		return pin;
+	};
+	int analogReadResolution() {
+		return getAnalogReadResolution();
+	};
+	bool operator== (NinaPin const & other) const {
+		return pin == other.pin;
+	}
+	//operator int() = delete;
+	__attribute__ ((error("Change me to a #define"))) operator int();
+private:
+	int pin;
 };
+
+extern NinaPin  LEDR;
+extern NinaPin  LEDG;
+extern NinaPin  LEDB;
+extern NinaPin  A4;
+extern NinaPin  A5;
+extern NinaPin  A6;
+extern NinaPin  A7;
+
+#define NINA_PINS_AS_CLASS
 
 /******************************************************************************
  * FUNCTION DECLARATION


### PR DESCRIPTION
Some sketches use a pattern like
```
int potpin = A5
```

Since NinaPin was an enum, the implicit cast was taking place, and any subsequent call to analogRead() would not use the Nina functions.

Works in conjunction with https://github.com/arduino-libraries/WiFiNINA/pull/180