### PR TITLE
Add API to WiFi class to configure wdog feed function

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -314,6 +314,18 @@ unsigned long arduino::WiFiClass::getTime() {
     return 0;
 }
 
+void arduino::WiFiClass::setFeedWatchdogFunc(voidPrtFuncPtr func)
+{
+  _feed_watchdog_func = func;
+}
+
+void arduino::WiFiClass::feedWatchdog()
+{
+  if (_feed_watchdog_func)
+	_feed_watchdog_func();
+}
+
+
 #if defined(COMPONENT_4343W)
 
 #include "QSPIFBlockDevice.h"

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -314,7 +314,7 @@ unsigned long arduino::WiFiClass::getTime() {
     return 0;
 }
 
-void arduino::WiFiClass::setFeedWatchdogFunc(voidPrtFuncPtr func)
+void arduino::WiFiClass::setFeedWatchdogFunc(ArduinoPortentaH7WiFiFeedWatchdogFuncPtr func)
 {
   _feed_watchdog_func = func;
 }

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -296,6 +296,9 @@ public:
 
     NetworkInterface *getNetwork();
 
+    void setFeedWatchdogFunc(voidPrtFuncPtr func);
+    void feedWatchdog();
+
 private:
 
     EMACInterface* _softAP = nullptr;
@@ -316,6 +319,7 @@ private:
     bool isVisible(const char* ssid);
     arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
     SocketAddress socketAddressFromIpAddress(arduino::IPAddress ip, uint16_t port);
+    voidPrtFuncPtr _feed_watchdog_func = 0;
 };
 
 }

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -49,6 +49,8 @@ extern "C" {
 #define DEFAULT_AP_CHANNEL 6
 #endif
 
+#define WIFI_HAS_FEED_WATCHDOG_FUNC
+
 namespace arduino {
 
 typedef void* (*voidPrtFuncPtr)(void);

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -54,6 +54,7 @@ extern "C" {
 namespace arduino {
 
 typedef void* (*voidPrtFuncPtr)(void);
+typedef void (*ArduinoPortentaH7WiFiFeedWatchdogFuncPtr)(void);
 
 class WiFiClass
 {
@@ -298,7 +299,7 @@ public:
 
     NetworkInterface *getNetwork();
 
-    void setFeedWatchdogFunc(voidPrtFuncPtr func);
+    void setFeedWatchdogFunc(ArduinoPortentaH7WiFiFeedWatchdogFuncPtr func);
     void feedWatchdog();
 
 private:
@@ -321,7 +322,7 @@ private:
     bool isVisible(const char* ssid);
     arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
     SocketAddress socketAddressFromIpAddress(arduino::IPAddress ip, uint16_t port);
-    voidPrtFuncPtr _feed_watchdog_func = 0;
+    ArduinoPortentaH7WiFiFeedWatchdogFuncPtr _feed_watchdog_func = 0;
 };
 
 }

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -49,7 +49,7 @@ extern "C" {
 #define DEFAULT_AP_CHANNEL 6
 #endif
 
-#define WIFI_HAS_FEED_WATCHDOG_FUNC
+#define ARDUINO_PORTENTA_H7_WIFI_HAS_FEED_WATCHDOG_FUNC
 
 namespace arduino {
 

--- a/libraries/WiFi/src/WiFiHelpers.cpp
+++ b/libraries/WiFi/src/WiFiHelpers.cpp
@@ -23,6 +23,7 @@ static FILE* target;
 
 void body_callback(const char* data, uint32_t data_len)
 {
+	WiFi.feedWatchdog();
 	fwrite(data, 1, data_len, target);
 }
 


### PR DESCRIPTION
This pr add the possibility to configure the watchdog feed function through API in the WiFi class and trigger the watchdog during download process.

(TODO implement timeout) -> this should go to Arduino_IoT_library i think

needs https://github.com/arduino-libraries/Arduino_Portenta_OTA/pull/10
and https://github.com/arduino-libraries/ArduinoIoTCloud/pull/261