### PR TITLE
Revert "Disable STDIN input to allow deepsleep"

### DIFF
--- a/cores/arduino/main.cpp
+++ b/cores/arduino/main.cpp
@@ -36,9 +36,6 @@ int main(void)
 	init();
 	initVariant();
 
-	// we are never going to use getchar/scanf directly
-	mbed::mbed_file_handle(STDIN_FILENO)->enable_input(false);
-
 #if defined(SERIAL_CDC)
   PluggableUSBD().begin();
   _SerialUSB.begin(115200);


### PR DESCRIPTION
Commit ec9a6a319b63471421228a9af8f60bb6cf89486a was introduced to reduce power consumption, but it actually has no effect on low power. On the contrary, it was preventing a correct functionality on Nano 33 BLE UART pins when used as GPIOs.
Reverting this commit solves issue #230.