### PR TITLE
Clean up AP data after ending it

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -99,6 +99,7 @@ void arduino::WiFiClass::ensureDefaultAPNetworkConfiguration() {
 
 void arduino::WiFiClass::end() {
   disconnect();
+  _softAP = nullptr;
 }
 
 int arduino::WiFiClass::disconnect() {


### PR DESCRIPTION
When using AP mode in conjunction with regular STA mode the state gets messed up after calling WiFi.end(). The reason is that the AP variable doesn't get reset. Calling e.g. localIP() after disconnecting AP and connecting as STA it yields 0.0.0.0.
This PR fixes it. Side note: We should start thinking about reworking this API to properly handle both modes as well as dual mode.