### PR TITLE
PDM: Unload pio program when end method is called

### DIFF
--- a/libraries/PDM/src/rp2040/PDM.cpp
+++ b/libraries/PDM/src/rp2040/PDM.cpp
@@ -139,6 +139,8 @@ void PDMClass::end()
 {
   dma_channel_abort(dmaChannel);
   pinMode(_clkPin, INPUT);
+  decimation = 128;
+  rawBufferIndex = 0;
 }
 
 int PDMClass::available()


### PR DESCRIPTION
Fix PDM restart issue on RP2040
How to reproduce: PDM.begin() => record for a while => PDM.end() => stop for a while =>PDM.begin() several times...