### PR TITLE
Update install instructions to reflect symlink removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git clone git@github.com:arduino/ArduinoCore-API
 
 ### Update the `api` symlink
 
-Remove the symlink to `api` in `$sketchbook/hardware/arduino/mbed/cores/arduino` and replace it with a symlink to `ArduinoCore-API/api`.
+Create a symlink to `ArduinoCore-API/api` in `$sketchbook/hardware/arduino/mbed/cores/arduino`.
 
 ### Test things out
 


### PR DESCRIPTION
The symlink in the core library targeting ArduinoCore-API has been removed (ca397e8), which means it's no long necessary to remove the symlink when installing the Arduino Mbed OS Boards platform manually. The instructions still mentioned the obsolete symlink removal step, which might result in confusion for the reader.