### PR TITLE
Fixes the preprocess linkerscript

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -82,7 +82,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -DARDUIN
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Preprocess linker script
-recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.elf.cmd}" -E -P -x c {build.extra_flags} {build.extra_ldflags} "{build.variant.path}/{build.ldscript}" -o {build.path}/{build.ldscript}
+recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.elf.cmd}" -E -P -x c {build.extra_ldflags} "{build.variant.path}/{build.ldscript}" -o {build.path}/{build.ldscript}
 
 ## Combine gc-sections, archives, and objects
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}"  "-L{build.path}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} {build.extra_flags} {build.extra_ldflags} "@{compiler.mbed.ldflags}" "-T{build.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" --specs=nosys.specs {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} -Wl,--whole-archive "{build.path}/{archive_file}" {compiler.mbed} -Wl,--no-whole-archive -Wl,--start-group {compiler.mbed.extra_ldflags} {compiler.libraries.ldflags} -Wl,--end-group


### PR DESCRIPTION
When building with `arduino-cli` and passing the `--build-property` flag the build process fails with a linkerscript syntax error, like below:

``` sh
 /home/raul/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/../lib/gcc/arm-non
 e-eabi/7.2.1/../../../../arm-none-eabi/bin/ld:/tmp/arduino-sketch-C67EA27C1A6288EDF2ADFFE6011F
 B7D3/linker_script.ld:1: ignoring invalid character '#' in expression
 /home/raul/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin/../lib/gcc/arm-non
 e-eabi/7.2.1/../../../../arm-none-eabi/bin/ld:/tmp/arduino-sketch-C67EA27C1A6288EDF2ADFFE6011F
 B7D3/linker_script.ld:1: syntax error
 collect2: error: ld returned 1 exit status
```

It appears the linkerscript contains build flags in `#SOME-MACRO` format.

Removing `{build.extra_flags}` fixes the issue.