### PR TITLE
Don't call slave->stop()

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -162,7 +162,7 @@ void arduino::MbedI2C::receiveThd() {
 				if (rxBuffer.available() > 0 && onReceiveCb != NULL) {
 					onReceiveCb(rxBuffer.available());
 				}
-				slave->stop();
+				//slave->stop();
 				break;
 		case mbed::I2CSlave::NoData:
 			//slave->stop();


### PR DESCRIPTION
Fixes: I2C slave read callback is executed only once

| Board |  |
| ----------- | ----------- |
| PORTENTA | :heavy_check_mark:  |
| RP2040 |  Not worse than now but needs :rescue_worker_helmet: |
| NANO33BLE|  :heavy_check_mark:  |

/cc @facchinm 