### PR TITLE
Portenta: PDM: use PLL3 to clock SAI

### DIFF
--- a/libraries/PDM/src/stm32/audio.c
+++ b/libraries/PDM/src/stm32/audio.c
@@ -148,9 +148,9 @@ int py_audio_init(size_t channels, uint32_t frequency, int gain_db, float highpa
     if((frequency == AUDIO_FREQUENCY_11K) || (frequency == AUDIO_FREQUENCY_22K) || (frequency == AUDIO_FREQUENCY_44K))
     {
         /* SAI clock config:
-        PLL2_VCO Input = HSE_VALUE/PLL2M = 1 Mhz
-        PLL2_VCO Output = PLL2_VCO Input * PLL2N = 429 Mhz
-        SAI_CLK_x = PLL2_VCO Output/PLL2P = 429/38 = 11.289 Mhz */
+        PLL3_VCO Input = HSE_VALUE/PLL3M = 1 Mhz
+        PLL3_VCO Output = PLL3_VCO Input * PLL3N = 429 Mhz
+        SAI_CLK_x = PLL3_VCO Output/PLL3P = 429/38 = 11.289 Mhz */
         rcc_ex_clk_init_struct.PeriphClockSelection = RCC_PERIPHCLK_SAI4A;
         rcc_ex_clk_init_struct.Sai4AClockSelection = RCC_SAI4ACLKSOURCE_PLL3;
         rcc_ex_clk_init_struct.PLL3.PLL3P = 38;
@@ -161,9 +161,9 @@ int py_audio_init(size_t channels, uint32_t frequency, int gain_db, float highpa
 
     } else {
         /* SAI clock config:
-        PLL2_VCO Input = HSE_VALUE/PLL2M = 1 Mhz
-        PLL2_VCO Output = PLL2_VCO Input * PLL2N = 344 Mhz
-        sai_x_ker_ck = PLL2_VCO Output/PLL2P = 344/7 = 49.142 Mhz */
+        PLL3_VCO Input = HSE_VALUE/PLL3M = 1 Mhz
+        PLL3_VCO Output = PLL3_VCO Input * PLL3N = 344 Mhz
+        sai_x_ker_ck = PLL3_VCO Output/PLL3P = 344/7 = 49.142 Mhz */
         rcc_ex_clk_init_struct.PeriphClockSelection = RCC_PERIPHCLK_SAI4A;
         rcc_ex_clk_init_struct.Sai4AClockSelection = RCC_SAI4ACLKSOURCE_PLL3;
         rcc_ex_clk_init_struct.PLL3.PLL3P = 7;


### PR DESCRIPTION
This PLL is not used by any other library, so we can reserve for PDM since it changes all the multipliers to match the required sample rate.

@rajames

Fixes https://github.com/edgeimpulse/firmware-arduino-portenta-internal/issues/5 