### PR TITLE
Disable DMA_IRQ_0n when stopping PDM peripheral

### DIFF
--- a/libraries/PDM/src/rp2040/PDM.cpp
+++ b/libraries/PDM/src/rp2040/PDM.cpp
@@ -145,6 +145,7 @@ int PDMClass::begin(int channels, int sampleRate)
 
 void PDMClass::end()
 {
+  NVIC_DisableIRQ(DMA_IRQ_0n);
   pio_remove_program(pio, &pdm_pio_program, offset);
   dma_channel_abort(dmaChannel);
   pinMode(_clkPin, INPUT);


### PR DESCRIPTION
Otherwise using serial interface after stopping the PDM peripheral will cause an mbed-os crash