### PR TITLE
Fix binary size calculation on rp2040

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -99,7 +99,7 @@ recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
 recipe.size.regex.data=^(?:\.data|\.bss)\s+([0-9]+).*
-recipe.size.regex=^(?:\.data|\.text)\s+([0-9]+).*
+recipe.size.regex=^(?:\.data|\.text)\S*?\s+([0-9]+).*
 
 ## Save hex
 recipe.output.tmp_file={build.project_name}.bin


### PR DESCRIPTION
RP2040 linker splits the .text section into different lines (one per object) so the regex must be updated to take this into account