### PR TITLE
Quote linker script path in compilation recipe

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -82,7 +82,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -DARDUIN
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Preprocess linker script
-recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.elf.cmd}" -E -P -x c {build.extra_ldflags} "{build.variant.path}/{build.ldscript}" -o {build.path}/{build.ldscript}
+recipe.hooks.linking.prelink.1.pattern="{compiler.path}{compiler.c.elf.cmd}" -E -P -x c {build.extra_ldflags} "{build.variant.path}/{build.ldscript}" -o "{build.path}/{build.ldscript}"
 
 ## Combine gc-sections, archives, and objects
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}"  "-L{build.path}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} {build.extra_flags} {build.extra_ldflags} "@{compiler.mbed.ldflags}" "-T{build.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" --specs=nosys.specs {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} -Wl,--whole-archive "{build.path}/{archive_file}" {compiler.mbed} -Wl,--no-whole-archive -Wl,--start-group {compiler.mbed.extra_ldflags} {compiler.libraries.ldflags} -Wl,--end-group


### PR DESCRIPTION
An unquoted path to the linker script caused compilation to fail when the temporary build folder path contained spaces:

```
$ arduino-cli compile --fqbn arduino:mbed_portenta:envie_m7 --build-path "/tmp/some path with spaces"
arm-none-eabi-g++: error: path: No such file or directory
arm-none-eabi-g++: error: with: No such file or directory
arm-none-eabi-g++: error: spaces/linker_script.ld: No such file or directory
```
The above demo uses Arduino CLI as an easy way to guarantee the build path has spaces, but this bug affects users of all Arduino development software with a space in their temporary folder path (e.g., Windows users with a space in their user name) under normal conditions.