### PR TITLE
Add getter function for Timer and LPTimer

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -100,6 +100,7 @@ extern analogin_config_t adcCurrentConfig;
 #endif
 
 #include "Serial.h"
+#include "timer.h"
 #if defined(SERIAL_CDC)
 #define Serial _UART_USB_
 #define SerialUSB _UART_USB_

--- a/cores/arduino/timer.cpp
+++ b/cores/arduino/timer.cpp
@@ -10,14 +10,18 @@ struct _mbed_timer {
 
 ArduinoTimer::ArduinoTimer(void* _timer) {
 
-	if (timer == NULL) {
-		timer = new mbed_timer;
-		timer->obj = NULL;
-	}
-	if (timer->obj == NULL) {
-		timer->obj = (mbed::Timer*)_timer;
+	if (timer != NULL) {
+		delete timer;
 	}
 
+	timer = new mbed_timer;
+	timer->obj = (mbed::Timer*)_timer;
+}
+
+ArduinoTimer::~ArduinoTimer() {
+	if (timer != NULL) {
+		delete timer;
+	}
 }
 
 void ArduinoTimer::start() {

--- a/cores/arduino/timer.cpp
+++ b/cores/arduino/timer.cpp
@@ -1,0 +1,29 @@
+#include "Arduino.h"
+#include "timer.h"
+#include "mbed.h"
+
+using namespace arduino;
+
+struct _mbed_timer {
+	mbed::Timer* obj;
+};
+
+ArduinoTimer::ArduinoTimer(void* _timer) {
+
+	if (timer == NULL) {
+		timer = new mbed_timer;
+		timer->obj = NULL;
+	}
+	if (timer->obj == NULL) {
+		timer->obj = (mbed::Timer*)_timer;
+	}
+
+}
+
+void ArduinoTimer::start() {
+  timer->obj->start();
+}
+
+void ArduinoTimer::stop() {
+  timer->obj->stop();
+}

--- a/cores/arduino/timer.h
+++ b/cores/arduino/timer.h
@@ -1,8 +1,31 @@
-#include "mbed.h"
+#include "Arduino.h"
+
+#ifndef __ARDUINO_TIMER_H__
+#define __ARDUINO_TIMER_H__
 
 enum TimerType {
   TIMER = 0x1,
   LPTIMER = 0x2
 };
 
-mbed::Timer* getTimer(TimerType t = TIMER);
+typedef struct _mbed_timer mbed_timer;
+
+namespace arduino {
+
+  class ArduinoTimer {
+    public:
+      ArduinoTimer(void* _timer);
+      void start();
+      void stop();
+
+    private:
+      mbed_timer* timer = NULL;
+  };
+
+}
+
+arduino::ArduinoTimer getTimer(TimerType t = TIMER);
+
+#endif //__ARDUINO_TIMER_H__
+
+

--- a/cores/arduino/timer.h
+++ b/cores/arduino/timer.h
@@ -1,0 +1,8 @@
+#include "mbed.h"
+
+enum TimerType {
+  TIMER = 0x1,
+  LPTIMER = 0x2
+};
+
+mbed::Timer* getTimer(TimerType t = TIMER);

--- a/cores/arduino/timer.h
+++ b/cores/arduino/timer.h
@@ -15,6 +15,7 @@ namespace arduino {
   class ArduinoTimer {
     public:
       ArduinoTimer(void* _timer);
+      ~ArduinoTimer();
       void start();
       void stop();
 

--- a/cores/arduino/wiring.cpp
+++ b/cores/arduino/wiring.cpp
@@ -68,12 +68,12 @@ void init()
   lowPowerTimer.start();
 }
 
-mbed::Timer* getTimer(TimerType t)
+ArduinoTimer getTimer(TimerType t)
 {
   if (t == LPTIMER) {
-    return (mbed::Timer*)(&lowPowerTimer);
+    return ArduinoTimer((mbed::Timer*)(&lowPowerTimer));
   } else {
-    return &timer;
+    return ArduinoTimer(&timer);
   }
 }
 

--- a/cores/arduino/wiring.cpp
+++ b/cores/arduino/wiring.cpp
@@ -68,6 +68,15 @@ void init()
   lowPowerTimer.start();
 }
 
+mbed::Timer* getTimer(TimerType t)
+{
+  if (t == LPTIMER) {
+    return (mbed::Timer*)(&lowPowerTimer);
+  } else {
+    return &timer;
+  }
+}
+
 void yield() {
 #ifndef NO_RTOS
   rtos::ThisThread::yield();


### PR DESCRIPTION
This PR introduces a new class `ArduinoTimer` with APIs to start/stop a timer.
A getter function is provided: `ArduinoTimer getTimer(Timer t = TIMER);`.

To start and stop a Timer from sketch:
```
ArduinoTimer t = getTimer();   //Get the standard Timer
OR
ArduinoTimer t = getTimer(LPTIMER);   //Get the Low Power Timer
t.start();
t.stop();
```
