### PR TITLE
Change the default SPI & I2C pins to match pinout docs

### DIFF
--- a/variants/RASPBERRY_PI_PICO/pins_arduino.h
+++ b/variants/RASPBERRY_PI_PICO/pins_arduino.h
@@ -42,10 +42,10 @@ static const uint8_t A3  = PIN_A3;
 #define PIN_SERIAL_RX (1ul)
 
 // SPI
-#define PIN_SPI_MISO  (4u)
-#define PIN_SPI_MOSI  (3u)
-#define PIN_SPI_SCK   (2u)
-#define PIN_SPI_SS    (5u)
+#define PIN_SPI_MISO  (16u)
+#define PIN_SPI_MOSI  (19u)
+#define PIN_SPI_SCK   (18u)
+#define PIN_SPI_SS    (17u)
 
 static const uint8_t SS   = PIN_SPI_SS;   // SPI Slave SS not used. Set here only for reference.
 static const uint8_t MOSI = PIN_SPI_MOSI;
@@ -53,8 +53,8 @@ static const uint8_t MISO = PIN_SPI_MISO;
 static const uint8_t SCK  = PIN_SPI_SCK;
 
 // Wire
-#define PIN_WIRE_SDA        (6u)
-#define PIN_WIRE_SCL        (7u)
+#define PIN_WIRE_SDA        (4u)
+#define PIN_WIRE_SCL        (5u)
 
 #define SERIAL_HOWMANY		1
 #define SERIAL1_TX			(digitalPinToPinName(PIN_SERIAL_TX))


### PR DESCRIPTION
This PR changes the default pins for SPI and I2C to match the ones marked as default in the [official raspberry pi pico pinout](https://datasheets.raspberrypi.com/pico/Pico-R3-A4-Pinout.pdf).

This has already been discussed in issue #194 but I couldn't understand if this change was desired or not but I decided to submit it anyways.

I've tested it with I2C and it works. Unfortunately I could not test with SPI.

Please excuse me if I'm missing something when it comes to PRs in this repository. Finally, thank you very much for your hard work on this project.