### PR TITLE
Add WiFI.config() functionality to mbed Wifi Library

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -30,6 +30,12 @@ int arduino::WiFiClass::begin(const char* ssid, const char* passphrase) {
   return _currentNetworkStatus;
 }
 
+//Config Wifi to set Static IP && Disable DHCP
+void arduino::WiFiClass::config(const char* localip, const char* netmask, const char* gateway){
+  wifi_if->set_network(localip, netmask, gateway);
+  wifi_if->set_dhcp(false);
+}
+
 int arduino::WiFiClass::beginAP(const char* ssid, const char* passphrase, uint8_t channel) {
 
 #if defined(COMPONENT_4343W_FS)

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -85,6 +85,8 @@ public:
      *        must be between ASCII 32-126 (decimal).
      */
   int begin(const char* ssid, const char* passphrase);
+	
+  void config(const char* localip, const char* netmask, const char* gateway);
 
   int beginAP(const char* ssid, const char* passphrase, uint8_t channel = DEFAULT_AP_CHANNEL);
 


### PR DESCRIPTION
I noticed that WiFi.config does not exist in the wifi library on this board to setup a static ip.

Added:
WiFi.Config(IPV4,SUBNET,GATEWAY); function back to set the network address and disable DHCP for static station mode wifi setup.