### PR TITLE
`Ethernet::MACAddress()` implementation

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -84,4 +84,9 @@ unsigned long arduino::EthernetClass::getTime() {
   return 0;
 }
 
+void arduino::EthernetClass::MACAddress(uint8_t *mac_address)
+{
+  macAddress(mac_address);
+}
+
 arduino::EthernetClass Ethernet;


### PR DESCRIPTION
Use Mbed's `macAddress()` implementation for Arduino `MACAddress()`

The Mac Address seems to be stable/valid only after `::begin()`,
However, I can't explain myself why my Portenta H7's OUI `2B:00:1B` cannot be found on the various OUI databases available on internet.