### PR TITLE
[WIP] Manage TLS Server Name Indication

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -178,7 +178,15 @@ int arduino::MbedClient::connectSSL(IPAddress ip, uint16_t port) {
   return connectSSL(SocketHelpers::socketAddressFromIpAddress(ip, port));
 }
 
-int arduino::MbedClient::connectSSL(const char *host, uint16_t port) {
+int arduino::MbedClient::connectSSL(const char *host, uint16_t port, bool disableSNI) {
+  if (!disableSNI) {
+    if (sock == nullptr) {
+      sock = new TLSSocket();
+      _own_socket = true;
+    }
+    static_cast<TLSSocket *>(sock)->set_hostname(host);
+  }
+
   SocketAddress socketAddress = SocketAddress();
   socketAddress.set_port(port);
   getNetwork()->gethostbyname(host, &socketAddress);

--- a/libraries/SocketWrapper/src/MbedClient.h
+++ b/libraries/SocketWrapper/src/MbedClient.h
@@ -71,7 +71,7 @@ public:
   int connect(const char* host, uint16_t port);
   int connectSSL(SocketAddress socketAddress);
   int connectSSL(IPAddress ip, uint16_t port);
-  int connectSSL(const char* host, uint16_t port);
+  int connectSSL(const char* host, uint16_t port, bool disableSNI = false);
   size_t write(uint8_t);
   size_t write(const uint8_t* buf, size_t size);
   int available();

--- a/libraries/SocketWrapper/src/MbedSSLClient.cpp
+++ b/libraries/SocketWrapper/src/MbedSSLClient.cpp
@@ -1,5 +1,5 @@
 #include "MbedSSLClient.h"
 
-arduino::MbedSSLClient::MbedSSLClient() {
+arduino::MbedSSLClient::MbedSSLClient(): _disableSNI{false} {
   onBeforeConnect(mbed::callback(this, &MbedSSLClient::setRootCA));
 };

--- a/libraries/SocketWrapper/src/MbedSSLClient.h
+++ b/libraries/SocketWrapper/src/MbedSSLClient.h
@@ -38,13 +38,18 @@ public:
     return connectSSL(ip, port);
   }
   int connect(const char* host, uint16_t port) {
-    return connectSSL(host, port);
+    return connectSSL(host, port, _disableSNI);
+  }
+  void disableSNI(bool statusSNI) {
+    _disableSNI = statusSNI;
   }
 
 private:
   int setRootCA() {
     return ((TLSSocket*)sock)->set_root_ca_cert_path("/wlan/");
   }
+
+  bool _disableSNI;
 };
 
 }

--- a/libraries/WiFi/src/WiFiSSLClient.cpp
+++ b/libraries/WiFi/src/WiFiSSLClient.cpp
@@ -1,5 +1,5 @@
 #include "WiFiSSLClient.h"
 
-arduino::WiFiSSLClient::WiFiSSLClient() {
+arduino::WiFiSSLClient::WiFiSSLClient(): _disableSNI{false}  {
   onBeforeConnect(mbed::callback(this, &WiFiSSLClient::setRootCA));
 };

--- a/libraries/WiFi/src/WiFiSSLClient.h
+++ b/libraries/WiFi/src/WiFiSSLClient.h
@@ -38,13 +38,18 @@ public:
     return connectSSL(ip, port);
   }
   int connect(const char* host, uint16_t port) {
-    return connectSSL(host, port);
+    return connectSSL(host, port, _disableSNI);
+  }
+    void disableSNI(bool statusSNI) {
+    _disableSNI = statusSNI;
   }
 
 private:
   int setRootCA() {
     return ((TLSSocket*)sock)->set_root_ca_cert_path("/wlan/");
   }
+
+  bool _disableSNI;
 };
 
 }


### PR DESCRIPTION
Enable Server Name Indication by default for TLS connections (recommended and mandatory configuration) and add a method for explicitly disabling it.