### PR TITLE
fix crash with some compilers due to missing return statement

### DIFF
--- a/libraries/Nicla_System/src/Nicla_System.cpp
+++ b/libraries/Nicla_System/src/Nicla_System.cpp
@@ -32,6 +32,8 @@ bool nicla::begin()
   th.start(&nicla::pingI2CThd);
 #endif
   started = true;
+
+  return true;
 }
 
 void nicla::enableCD()


### PR DESCRIPTION
fix crash with some compiler or building environment due to missing return statement when the compiler does not insert a default return instruction