### PR TITLE
Fix: short delay prevented new code uploads.

### DIFF
--- a/libraries/USBHID/examples/Keyboard/Keyboard.ino
+++ b/libraries/USBHID/examples/Keyboard/Keyboard.ino
@@ -9,7 +9,9 @@ void setup() {
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
-  delay(1000);
+  // Every 30 seconds, write `Hello world\n\r` to the connected computer as though the arduino were a keyboard.
+  // WARNING: Decreasing this delay could render the arduino useless, as the frequent newlines will make uploading new code 
+  //          nearly impossible. See [this issue](https://github.com/arduino/ArduinoCore-mbed/issues/424) for details
+  delay(30000);
   Keyboard.printf("Hello world\n\r");
 }


### PR DESCRIPTION
When the Arduino is treated as a keyboard and automatically typed `Hello world\n\r` every second, it was nearly impossible to upload new code due to the typing interfering with manually choosing the correct port. See [this issue](https://github.com/arduino/ArduinoCore-mbed/issues/424) for more details.

Mitigates [this issue](https://github.com/arduino/ArduinoCore-mbed/issues/424).