### PR TITLE
Use build path containing spaces for sketch compilation "smoke tests"

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -126,6 +126,10 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@v1
         with:
+          cli-compile-flags: |
+            # Use build path containing spaces to check for path quoting problems in compilation patterns
+            - --build-path
+            - ${{ runner.temp }}/path with spaces
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fqbn: ${{ matrix.board.fqbn }}
           libraries: |


### PR DESCRIPTION
Using a custom build path containing spaces for the sketch compilations done by the "Compile Examples" GitHub Actions
workflow will catch insufficient path quoting in the compilation patterns defined by the platform.

You can see a demonstration of how it would have caught https://github.com/arduino/ArduinoCore-mbed/pull/363 here where I have backported the workflow configuration change to the 2.6.1 tag where the project had insufficient path quoting:

https://github.com/per1234/ArduinoCore-mbed/runs/5686506549?check_suite_focus=true#step:5:83

```text
Compiling sketch: libraries/Scheduler/examples/MultipleBlinks
  arm-none-eabi-g++: error: with: No such file or directory
  arm-none-eabi-g++: error: spaces/linker_script.ld: No such file or directory
  
  
  Error during build: exit status 1
```