### PR TITLE
Drastically speedup client.read() operation

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -213,7 +213,7 @@ size_t arduino::MbedClient::write(const uint8_t *buf, size_t size) {
   int ret = NSAPI_ERROR_WOULD_BLOCK;
   do {
     ret = sock->send(buf, size);
-  } while (ret != size && connected());
+  } while ((ret != size && ret == NSAPI_ERROR_WOULD_BLOCK) && connected());
   configureSocket(sock);
   return size;
 }

--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -21,7 +21,6 @@ void arduino::MbedClient::readSocket() {
     do {
       if (rxBuffer.availableForStore() == 0) {
         yield();
-        delay(100);
         continue;
       }
       mutex->lock();
@@ -34,7 +33,6 @@ void arduino::MbedClient::readSocket() {
       }
       if (ret == NSAPI_ERROR_WOULD_BLOCK || ret == 0) {
         yield();
-        delay(100);
         mutex->unlock();
         continue;
       }
@@ -71,7 +69,7 @@ void arduino::MbedClient::configureSocket(Socket *_s) {
   }
   mutex->lock();
   if (reader_th == nullptr) {
-    reader_th = new rtos::Thread;
+    reader_th = new rtos::Thread(osPriorityNormal - 2);
     reader_th->start(mbed::callback(this, &MbedClient::readSocket));
   }
   mutex->unlock();

--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -78,6 +78,15 @@ void arduino::MbedClient::configureSocket(Socket *_s) {
 }
 
 int arduino::MbedClient::connect(SocketAddress socketAddress) {
+
+  if (sock && reader_th) {
+    // trying to reuse a connection, let's call stop() to cleanup the state
+    char c;
+    if (sock->recv(&c, 1) < 0) {
+      stop();
+    }
+  }
+
   if (sock == nullptr) {
     sock = new TCPSocket();
     _own_socket = true;

--- a/libraries/SocketWrapper/src/MbedClient.h
+++ b/libraries/SocketWrapper/src/MbedClient.h
@@ -73,7 +73,7 @@ public:
   int connectSSL(IPAddress ip, uint16_t port);
   int connectSSL(const char* host, uint16_t port, bool disableSNI = false);
   size_t write(uint8_t);
-  size_t write(const uint8_t* buf, size_t size);
+  size_t write(const uint8_t* buf, size_t size) override;
   int available();
   int read();
   int read(uint8_t* buf, size_t size);


### PR DESCRIPTION
Since the data being consumed by the reader thread is going to be read somewhere via read() APIs (that are known to be fair and call yield()), we can avoid the delay() when the buffer needs to be flushed by setting the reader thread priority to something lower than the main thread.

To be tested on some real world applications (by now, tested with Ethernet/WiFi Client/Server "basic" examples)

Fixes #438 

@manchoz 