### PR TITLE
Fix unsigned int overload: write(0u)

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -57,10 +57,10 @@ class MbedI2C : public HardwareI2C
     virtual void onRequest(void(*)(void));
 
     virtual size_t write(uint8_t data);
-    virtual size_t write(int data) {
+    virtual size_t write(intmax_t data) {
       return write ((uint8_t)data);
     };
-    virtual size_t write(unsigned int data) {
+    virtual size_t write(uintmax_t data) {
       return write ((uint8_t)data);
     };
     virtual size_t write(const uint8_t* data, int len);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -60,6 +60,9 @@ class MbedI2C : public HardwareI2C
     virtual size_t write(int data) {
       return write ((uint8_t)data);
     };
+    virtual size_t write(int data) {
+      return write ((uint8_t)data);
+    };
     virtual size_t write(const uint8_t* data, int len);
     using Print::write;
     virtual int read();

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -60,7 +60,7 @@ class MbedI2C : public HardwareI2C
     virtual size_t write(int data) {
       return write ((uint8_t)data);
     };
-    virtual size_t write(int data) {
+    virtual size_t write(unsigned int data) {
       return write ((uint8_t)data);
     };
     virtual size_t write(const uint8_t* data, int len);


### PR DESCRIPTION
`Wire::write(0u)` is otherwise ambiguous in modern C++ compilers, introduced by commit 2958bc00a985cbe5b63400fb4afa117453750255