### PR TITLE
Rename Serial objects if CDC UART is not available

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -104,13 +104,16 @@ extern analogin_config_t adcCurrentConfig;
 #if defined(SERIAL_CDC)
 #define Serial _UART_USB_
 #define SerialUSB _UART_USB_
-#else
-#define Serial _UART1_
-#endif
 #define Serial1 _UART1_
 #define Serial2 _UART2_
 #define Serial3 _UART3_
 #define Serial4 _UART4_
+#else
+#define Serial  _UART1_
+#define Serial1 _UART2_
+#define Serial2 _UART3_
+#define Serial3 _UART4_
+#endif
 
 #include "overloads.h"
 #endif


### PR DESCRIPTION
Fixes https://github.com/arduino/nicla-sense-me-fw/issues/55

@per1234 @sebromero does it look ok? I remember we had some conversation about the naming on platforms like PORTENTA_H7_M4, where we would lose the alignment between cores (the same pins would be referred as Serial on M4 and Serial1 on M7)