### PR TITLE
Fix pico.upload.maximum_size

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -414,7 +414,7 @@ pico.upload.transport=
 pico.upload.use_1200bps_touch=true
 pico.upload.wait_for_upload_port=false
 pico.upload.native_usb=true
-pico.upload.maximum_size=16777216
+pico.upload.maximum_size=2097152
 pico.upload.maximum_data_size=270336
 
 pico.bootloader.tool=openocd

--- a/platform.txt
+++ b/platform.txt
@@ -101,7 +101,7 @@ recipe.hooks.objcopy.postobjcopy.1.pattern={build.postbuild.cmd}
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
 recipe.size.regex.data=^(?:\.data|\.bss)\s+([0-9]+).*
-recipe.size.regex=^(?:\.data|\.text)\S*?\s+([0-9]+).*
+recipe.size.regex=^(?:\.data|\.text|\.rodata)\S*?\s+([0-9]+).*
 
 ## Save hex
 recipe.output.tmp_file={build.project_name}.bin


### PR DESCRIPTION
Even though the RP2040 supports up to 16 MiB of flash, the Pi Pico only has 2 MiB installed. (<https://www.raspberrypi.com/products/raspberry-pi-pico/specifications>)

This change also fixes the percentage of program storage space in use reported by the builder/IDE.

The linker file does specify the correct size: 
https://github.com/arduino/ArduinoCore-mbed/blob/8d5510ad677ff84dcfbc0fe9626c9d1cb4329763/variants/RASPBERRY_PI_PICO/linker_script.ld#L3