### PR TITLE
Use NRF_LF_SRC_SYNTH as 32k clock source

### DIFF
--- a/variants/ARDUINO_NANO33BLE/conf/mbed_app.json
+++ b/variants/ARDUINO_NANO33BLE/conf/mbed_app.json
@@ -5,6 +5,7 @@
   ],
   "target_overrides": {
     "*": {
+      "target.lf_clock_src":"NRF_LF_SRC_SYNTH",
       "target.printf_lib": "std",
       "platform.stdio-buffered-serial": false,
       "platform.stdio-baud-rate": 115200,

--- a/variants/ARDUINO_NANO33BLE/variant.cpp
+++ b/variants/ARDUINO_NANO33BLE/variant.cpp
@@ -135,11 +135,17 @@ extern "C" {
 #include "nrf_rtc.h"
 #include "nrf_uarte.h"
 #include "nrf_uart.h"
+#include "nrf_clock.h"
 
 void initVariant() {
   // turn power LED on
   pinMode(LED_PWR, OUTPUT);
   digitalWrite(LED_PWR, HIGH);
+
+  if (nrf_clock_int_enable_check(NRF_CLOCK_INT_LF_STARTED_MASK)) {
+    // NINA B306 01B modules (without 32k xtal)
+    nrf_clock_int_disable(NRF_CLOCK_INT_LF_STARTED_MASK);
+  }
 
   // Errata Nano33BLE - I2C pullup is controlled by the SWO pin.
   // Configure the TRACEMUX to disable routing SWO signal to pin.

--- a/variants/ARDUINO_NANO33BLE/variant.cpp
+++ b/variants/ARDUINO_NANO33BLE/variant.cpp
@@ -165,10 +165,12 @@ void initVariant() {
   digitalWrite(PIN_ENABLE_I2C_PULLUP, HIGH);
 
   // Disable UARTE0 which is initially enabled by the bootloader
-  nrf_uarte_task_trigger(NRF_UARTE0, NRF_UARTE_TASK_STOPRX); 
-  while (!nrf_uarte_event_check(NRF_UARTE0, NRF_UARTE_EVENT_RXTO)) ; 
-  NRF_UARTE0->ENABLE = 0; 
-  NRF_UART0->ENABLE = 0; 
+  if (nrf_uarte_event_check(NRF_UARTE0, NRF_UARTE_EVENT_RXTO)) {
+    nrf_uarte_task_trigger(NRF_UARTE0, NRF_UARTE_TASK_STOPRX);
+    while (!nrf_uarte_event_check(NRF_UARTE0, NRF_UARTE_EVENT_RXTO));
+    NRF_UARTE0->ENABLE = 0;
+    NRF_UART0->ENABLE = 0;
+  }
 
   NRF_PWM_Type* PWM[] = {
     NRF_PWM0, NRF_PWM1, NRF_PWM2


### PR DESCRIPTION
Nina 01B ship without the 32k onboard and are otherwise indistinguishable from 00B modules.

Don't merge this patch before running extensive tests on low power and BLE performance.

We can use the bootloader glitch (NRF_CLOCK_INT_LF_STARTED interrupt enabled and firing as soon as the USB starts, fixed in variant.cpp) to discriminate the boards if really needed.

Fixes #498 