### PR TITLE
PR: update camera.cpp for the PortentaM4 Core

### DIFF
--- a/libraries/Camera/src/camera.cpp
+++ b/libraries/Camera/src/camera.cpp
@@ -605,7 +605,7 @@ int Camera::grabFrame(FrameBuffer &fb, uint32_t timeout)
 
     HAL_DCMI_Suspend(&hdcmi);
 
-    #ifndef ARDUINO_PORTENTA_H7_M4  // do not invalidate if Portenta M4 Core
+    #if defined(__CORTEX_M7)  // only invalidate buffer for Cortex M7
        // Invalidate buffer after DMA transfer.
        SCB_InvalidateDCache_by_Addr((uint32_t*) framebuffer, framesize);
     #endif

--- a/libraries/Camera/src/camera.cpp
+++ b/libraries/Camera/src/camera.cpp
@@ -28,7 +28,7 @@
 #define ALIGN_PTR(p,a)   ((p & (a-1)) ?(((uintptr_t)p + a) & ~(uintptr_t)(a-1)) : p)
 
 // Include all image sensor drivers here.
-#ifdef ARDUINO_PORTENTA_H7_M7
+#if defined (ARDUINO_PORTENTA_H7_M7) || defined (ARDUINO_PORTENTA_H7_M4)
 
 #define DCMI_TIM                    (TIM1)
 #define DCMI_TIM_PIN                (GPIO_PIN_1)
@@ -65,7 +65,7 @@ arduino::MbedI2C CameraWire(I2C_SDA2, I2C_SCL2);
 
 // DCMI GPIO pins struct
 static const struct { GPIO_TypeDef *port; uint16_t pin; } dcmi_pins[] = {
-#ifdef ARDUINO_PORTENTA_H7_M7
+#if defined (ARDUINO_PORTENTA_H7_M7) || defined (ARDUINO_PORTENTA_H7_M4)
     {GPIOA,     GPIO_PIN_4  },
     {GPIOA,     GPIO_PIN_6  },
     {GPIOI,     GPIO_PIN_4  },
@@ -146,7 +146,7 @@ void HAL_DCMI_MspInit(DCMI_HandleTypeDef *hdcmi)
     hgpio.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
     hgpio.Alternate = GPIO_AF13_DCMI;
 
-#ifdef ARDUINO_PORTENTA_H7_M7
+#if defined (ARDUINO_PORTENTA_H7_M7) || defined (ARDUINO_PORTENTA_H7_M4)
     /* Enable GPIO clocks */
     __HAL_RCC_GPIOA_CLK_ENABLE();
     __HAL_RCC_GPIOH_CLK_ENABLE();
@@ -365,7 +365,7 @@ Camera::Camera(ImageSensor &sensor) :
 
 int Camera::reset()
 {
-#ifdef ARDUINO_PORTENTA_H7_M7
+#if defined (ARDUINO_PORTENTA_H7_M7) || defined (ARDUINO_PORTENTA_H7_M4)
     // Reset sensor.
     digitalWrite(PC_13, LOW);
     HAL_Delay(10);
@@ -605,9 +605,10 @@ int Camera::grabFrame(FrameBuffer &fb, uint32_t timeout)
 
     HAL_DCMI_Suspend(&hdcmi);
 
-    // Invalidate buffer after DMA transfer.
-    SCB_InvalidateDCache_by_Addr((uint32_t*) framebuffer, framesize);
-
+    #ifndef ARDUINO_PORTENTA_H7_M4  // do not invalidate if Portenta M4 Core
+       // Invalidate buffer after DMA transfer.
+       SCB_InvalidateDCache_by_Addr((uint32_t*) framebuffer, framesize);
+    #endif
     return 0;
 }
 


### PR DESCRIPTION


As per this issue [Feature Request: PortentaH7 Camera working using M4 #504](https://github.com/arduino/ArduinoCore-mbed/issues/504) and great suggestions from @facchinm I managed to get the Portenta M4 Camera working by making a few changes to the camera.cpp file. Specifcally adding 4 sets of 

```

#if defined (ARDUINO_PORTENTA_H7_M7) || defined (ARDUINO_PORTENTA_H7_M4)

```

The only hack I am a bit concerned about is [here](https://github.com/hpssjellis/ArduinoCore-mbed/blob/1c3150fa382689bdce1f4d483dff033328dea0a8/libraries/Camera/src/camera.cpp#L608-L611) where I excluded the following function using an ```#ifndef```

```

    #ifndef ARDUINO_PORTENTA_H7_M4  // do not invalidate if Portenta M4 Core
       // Invalidate buffer after DMA transfer.
       SCB_InvalidateDCache_by_Addr((uint32_t*) framebuffer, framesize);
    #endif

```

Not really sure if excluding the ```SCB_InvalidateDCache_by_Addr```  is the best solution for the M4 core.

I have tested the PR on both an [OLED program](https://github.com/hpssjellis/portenta-pro-community-solutions/blob/main/examples/dot3-portenta-vision-shields/dot35-camera-and-oled/dot351-camera-oled-regular/dot351-camera-oled-regular.ino) and an [edgeImpulse 64x64 FOMO Vision](https://github.com/hpssjellis/portenta-pro-community-solutions/tree/main/examples/dot5-portenta-machine-learning/dot51-portenta-edge-impulse-ml/dot514-vision-fomo/dot5146-oled-count) program as well as the standard [CameraMotionDetect](https://github.com/arduino/ArduinoCore-mbed/blob/master/libraries/Camera/examples/CameraMotionDetect/CameraMotionDetect.ino)  (flashes blue LED on motion.)