### PR TITLE
Always clean up previous I2C object before new to avoid leaking memory

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -28,11 +28,13 @@ arduino::MbedI2C::MbedI2C(int sda, int scl) : _sda(digitalPinToPinName(sda)), _s
 arduino::MbedI2C::MbedI2C(PinName sda, PinName scl) : _sda(sda), _scl(scl), usedTxBuffer(0), slave_th(osPriorityNormal, 2048, nullptr, "I2CSlave") {}
 
 void arduino::MbedI2C::begin() {
+	end();
 	master = new mbed::I2C(_sda, _scl);
 }
 
 void arduino::MbedI2C::begin(uint8_t slaveAddr) {
 #ifdef DEVICE_I2CSLAVE
+	end();
 	slave = new mbed::I2CSlave((PinName)_sda, (PinName)_scl);
 	slave->address(slaveAddr << 1);
 	slave_th.start(mbed::callback(this, &arduino::MbedI2C::receiveThd));


### PR DESCRIPTION
I found a memory leak while debugging some code that was calling Wire.begin() repeatedly. The Wire implementation currently calls new each time but does not free up any previously allocated memory. Most other Wire.h implementations I've seen don't allocate any dynamic memory so calling begin() multiple times is not a problem.

This patch makes sure to call end() first to clean up any previous I2C object if one exists.