### PR TITLE
allow proper GPS functionality after disable

### DIFF
--- a/libraries/GPS/src/GPS.cpp
+++ b/libraries/GPS/src/GPS.cpp
@@ -197,7 +197,7 @@ void arduino::GPSClass::end()
     _engine = !checkGNSSEngine("^SGPSC: \"Engine\",\"0\"");
   }
 
-  _serial->write("^SSIO=7,0\r\n", sizeof("^SSIO=7,0\r\n"));
+  _serial->write("AT^SSIO=7,0\r\n", sizeof("AT^SSIO=7,0\r\n"));
   readAndDrop();
 }
 


### PR DESCRIPTION
arduino::GPSClass::end() was missing AT prefix on a command and this was confusing the module