### PR TITLE
Removed unused variable

### DIFF
--- a/libraries/Nicla_System/src/pmic_driver.cpp
+++ b/libraries/Nicla_System/src/pmic_driver.cpp
@@ -25,7 +25,6 @@ uint8_t BQ25120A::readByte(uint8_t address, uint8_t subAddress)
 {
   digitalWrite(p25, HIGH);
   nicla::i2c_mutex.lock();
-  char response = 0xFF;
   Wire1.beginTransmission(address);
   Wire1.write(subAddress);
   Wire1.endTransmission(false);


### PR DESCRIPTION
I removed the char "response" in the method readByte as it was unused and it would just give a compiler warning