### PR TITLE
Fix compilation warning on sleep_for

### DIFF
--- a/libraries/USBHID/src/USBMouse.cpp
+++ b/libraries/USBHID/src/USBMouse.cpp
@@ -21,6 +21,7 @@
 #include "usb_phy_api.h"
 
 using namespace arduino;
+using namespace std::chrono_literals;
 
 USBMouse::USBMouse(bool connect_blocking, MOUSE_TYPE mouse_type, uint16_t vendor_id, uint16_t product_id, uint16_t product_release):
     USBHID(get_usb_phy(), 0, 0, vendor_id, product_id, product_release)
@@ -149,7 +150,7 @@ bool USBMouse::double_click()
         _mutex.unlock();
         return false;
     }
-    rtos::ThisThread::sleep_for(100);
+    rtos::ThisThread::sleep_for(100ms);
     bool ret = click(MOUSE_LEFT);
 
     _mutex.unlock();
@@ -164,7 +165,7 @@ bool USBMouse::click(uint8_t button)
         _mutex.unlock();
         return false;
     }
-    rtos::ThisThread::sleep_for(10);
+    rtos::ThisThread::sleep_for(10ms);
     bool ret = update(0, 0, 0, 0);
 
     _mutex.unlock();

--- a/libraries/USBHID/src/USBMouseKeyboard.cpp
+++ b/libraries/USBHID/src/USBMouseKeyboard.cpp
@@ -21,6 +21,7 @@
 #include "ThisThread.h"
 
 using namespace arduino;
+using namespace std::chrono_literals;
 
 typedef struct {
     unsigned char usage;
@@ -703,7 +704,7 @@ bool USBMouseKeyboard::doubleClick()
         _mutex.unlock();
         return false;
     }
-    rtos::ThisThread::sleep_for(100);
+    rtos::ThisThread::sleep_for(100ms);
     bool ret = click(MOUSE_LEFT);
 
     _mutex.unlock();
@@ -718,7 +719,7 @@ bool USBMouseKeyboard::click(uint8_t button)
         _mutex.unlock();
         return false;
     }
-    rtos::ThisThread::sleep_for(10);
+    rtos::ThisThread::sleep_for(10ms);
     bool ret = update(0, 0, 0, 0);
 
     _mutex.unlock();


### PR DESCRIPTION
On compilation of any project using the USBHID library warnings appear as the library uses a function that was deprecated since mbed 6.0.0.

Previously opened an issue (#557) to get help on the missing imports.
