### PR TITLE
[Opta] Set default Ethernet MAC Address from OTP

### DIFF
--- a/variants/OPTA/pins_arduino.h
+++ b/variants/OPTA/pins_arduino.h
@@ -146,6 +146,9 @@ static const uint8_t SCK  = PIN_SPI_SCK;
 uint16_t _getVid_();
 uint16_t _getPid_();
 
+// Retrieve (Arduino OUI) Ethernet MAC Address from QSPIF OTP
+uint8_t _getSecureEthMac_(uint8_t *);
+
 #define BOARD_NAME			"Arduino Opta"
 
 #define DFU_MAGIC_SERIAL_ONLY_RESET   0xb0

--- a/variants/OPTA/variant.cpp
+++ b/variants/OPTA/variant.cpp
@@ -322,6 +322,21 @@ uint16_t _getPid_() {
 #endif
 }
 
+uint8_t _getSecureEthMac_(uint8_t *mac_address) {
+  if (!has_otp_info) {
+    getSecureFlashData();
+  }
+  memcpy(mac_address, ((OptaBoardInfo*)_boardInfo)->mac_address, 6);
+
+  return 6;
+}
+
+uint8_t mbed_otp_mac_address(char *mac)
+{
+  auto ret = _getSecureEthMac_(reinterpret_cast<uint8_t *>(mac));
+  return ret;
+}
+
 #define BOARD_REVISION(x,y)   (x << 8 | y)
 
 void initVariant() {


### PR DESCRIPTION
Set the default MAC Address for the Ethernet interface from the QSPIF's OTP area.

@facchinm 