### PR TITLE
SPI: fix crash on end() called before begin()

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -106,8 +106,10 @@ void arduino::MbedSPI::begin() {
 }
 
 void arduino::MbedSPI::end() {
-    if (dev->obj != NULL) {
+    if (dev != NULL && dev->obj != NULL) {
         delete dev->obj;
+        delete dev;
+        dev = NULL;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/arduino/ArduinoCore-mbed/issues/590

@RobTillaart 