### PR TITLE
SFU: add USBMSD binding only if included explicitly

### DIFF
--- a/libraries/SFU/src/SFU.h
+++ b/libraries/SFU/src/SFU.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "WiFiNINA.h"
+#include "FATFileSystem.h"
 
 class SFU {
 public:
 	static int begin();
 	static int download(const char* url);
 	static int apply();
+	static mbed::FATFileSystem& getFileSystem();
 };


### PR DESCRIPTION
Since SFU is being used for OTA on IotCloud, every sketch used to pull in USBMSD and expose a 1MB FAT disk when connected. This patch fixes this beahviour, providing the hooks only if the user explicitly includes "PluggableUSBMSD.h"
in the sketch (or in another library)

@ubidefeo 