### PR TITLE
Change maximum UDP datagram buffer size

### DIFF
--- a/libraries/SocketWrapper/src/MbedUdp.h
+++ b/libraries/SocketWrapper/src/MbedUdp.h
@@ -28,7 +28,7 @@
 #include "netsocket/UDPSocket.h"
 
 #ifndef WIFI_UDP_BUFFER_SIZE
-#define WIFI_UDP_BUFFER_SIZE 508
+#define WIFI_UDP_BUFFER_SIZE 2048
 #endif
 
 namespace arduino {


### PR DESCRIPTION
UDP packet will not send if its size is greater than 508, and the issue is hard to debug. I made this modification on my side and it works fine. Maybe add a warning if it is exceeded, instead of failing silently ?