### PR TITLE
Wire: Fix return value for read() when there is no data available.

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -120,7 +120,7 @@ int arduino::MbedI2C::read() {
 	if (rxBuffer.available()) {
 		return rxBuffer.read_char();
 	}
-	return 0;
+	return -1;
 }
 
 int arduino::MbedI2C::available() {


### PR DESCRIPTION
This PR fixes `Wire.read()` returning `0` instead of `-1` when there is no data available.

Fixes https://github.com/arduino/ArduinoCore-mbed/issues/601.