### PR TITLE
[TC-442][TC-443] Prevent mis-use of Blink_Nicla.ino sketch with Nicla Vision board

### DIFF
--- a/libraries/Nicla_System/examples/Blink_Nicla/Blink_Nicla.ino
+++ b/libraries/Nicla_System/examples/Blink_Nicla/Blink_Nicla.ino
@@ -1,13 +1,59 @@
-#include "Nicla_System.h"
+/*
+  Blink for Nicla Sense ME
+
+  Turns green LED on for one second, then turn it off.
+
+  Most Arduino boards have a single LED connected from D13 to ground
+  (with a current limiting resistor). In the Nicla Sense ME, the common
+  anode RGB LED (DL1) is controlled by a RGB LED Driver (U8). 
+  The RGB LED Driver state is set via I2C by the ANNA-B112 Module (MD1).
+
+ ┌────────────┐      ┌────────────┐
+ │  ANNA-B112 │      │ RGB-Driver │                 VPMID
+ │    MD-1    │      │     U8     │          Red     ─┬─
+ │            │      │        OUT3├────────◄──────┐   │
+ │            │ I2C  │            │          Green│   │
+ │            ├──────┤        OUT2├────────◄──────┼───┘
+ │            │      │            │          Blue │
+ │            │      │        OUT1├────────◄──────┘
+ │            │      │            │
+ │            │      │            │
+ │            │      │            │
+ └────────────┘      └────────┬───┘
+                              │
+                              ▼
+
+  All of this is abstracted via the Nicla_System.h header file. Details
+  on use for controling RGB LED can be found at:
+  https://docs.arduino.cc/tutorials/nicla-sense-me/cheat-sheet#rgb-led
+
+  More advanced users can look at the source code at:
+  https://github.com/arduino/ArduinoCore-mbed/blob/master/libraries/Nicla_System/src/Nicla_System.h 
+
+  Authors: Giulia Cioffi, Martino Facchin & Ali Jahangiri
+  
+  This example code is in the public domain.
+
+  Last edit: 2nd February 2023
+*/
+
+// Intialise library which communicates with RGB driver
+// Functions accessible under 'nicla' namespace
+#include "Nicla_System.h"       
+
 
 void setup() {
-  nicla::begin();
-  nicla::leds.begin();
+  //run this code once when Nicla Sense ME board turns on
+  nicla::begin();               // initialise library
+  nicla::leds.begin();          // Start I2C connection
 }
 
 void loop() {
-  nicla::leds.setColor(green);
-  delay(1000);
-  nicla::leds.setColor(off);
-  delay(1000);
+  //run this code in a loop
+  nicla::leds.setColor(green);  //turn green LED on
+  delay(1000);                  //wait 1 second
+  nicla::leds.setColor(off);    //turn all LEDs off
+  delay(1000);                  //wait 1 second
 }
+
+

--- a/libraries/Nicla_System/examples/Blink_Nicla/Blink_Nicla.ino
+++ b/libraries/Nicla_System/examples/Blink_Nicla/Blink_Nicla.ino
@@ -37,6 +37,11 @@
   Last edit: 2nd February 2023
 */
 
+//This sketch is only for the Nicla Sense ME, not the Nicla Vision
+#ifdef ARDUINO_NICLA_VISION
+  #error "Run the standard Blink.ino sketch for the Nicla Vision"
+
+
 // Intialise library which communicates with RGB driver
 // Functions accessible under 'nicla' namespace
 #include "Nicla_System.h"       

--- a/libraries/Nicla_System/examples/Blink_Nicla/Blink_Nicla.ino
+++ b/libraries/Nicla_System/examples/Blink_Nicla/Blink_Nicla.ino
@@ -40,7 +40,7 @@
 //This sketch is only for the Nicla Sense ME, not the Nicla Vision
 #ifdef ARDUINO_NICLA_VISION
   #error "Run the standard Blink.ino sketch for the Nicla Vision"
-
+#endif
 
 // Intialise library which communicates with RGB driver
 // Functions accessible under 'nicla' namespace


### PR DESCRIPTION
## What This PR Changes
- Add header explaining why this Blink sketch is needed (RGB LED not on D13)
- Add ASCII art
- Add comments to code
- Add error message
- Improve user experience:
    - https://github.com/arduino/ArduinoCore-mbed/issues/615
    - https://github.com/arduino/arduino-examples/issues/47
    - https://forum.arduino.cc/t/nicla-vision-example-fails/969623

## Please check
- Is the error message correct?
- Is it better practise to just declare `nicla` to be part of the namespace as we have done on the Docs website: https://docs.arduino.cc/tutorials/nicla-sense-me/cheat-sheet#rgb-led?
    - ![image](https://user-images.githubusercontent.com/75624145/216433544-ad0f4b02-6a48-46c1-b201-e022e6d19e32.png)