### PR TITLE
QSPIFormat: stop execution if error occurs

### DIFF
--- a/libraries/STM32H747_System/examples/QSPIFormat/QSPIFormat.ino
+++ b/libraries/STM32H747_System/examples/QSPIFormat/QSPIFormat.ino
@@ -74,11 +74,13 @@ void setup() {
     int err = wifi_data_fs.reformat(&wifi_data);
     if (err) {
       Serial.println("Error formatting WiFi partition");
+      return;
     }
   
     err = ota_data_fs.reformat(&ota_data);
     if (err) {
       Serial.println("Error formatting OTA partition");
+      return;
     }
 
     if(!default_scheme) {
@@ -96,6 +98,7 @@ void setup() {
       err = user_data_fs->reformat(&user_data);
       if (err) {
         Serial.println("Error formatting user partition");
+        return;
       }
     }
     Serial.println("\nQSPI Flash formatted!");


### PR DESCRIPTION
Immediately stop execution if an error occurs, otherwise misleading messages are printed in the serial monitor:

```
...
WARNING! Running the sketch all the content of the QSPI flash will be erased.
Do you want to proceed? Y/[n]
Error formatting WiFi partition
Error formatting OTA partition
QSPI Flash formatted!
It's now safe to reboot or disconnect your board.
```