### PR TITLE
HttpsRequest: Set hostname from url

### DIFF
--- a/libraries/SocketWrapper/src/utility/https_request.h
+++ b/libraries/SocketWrapper/src/utility/https_request.h
@@ -61,6 +61,7 @@ public:
 
         _socket = new TLSSocket();
         ((TLSSocket*)_socket)->open(network);
+        ((TLSSocket*)_socket)->set_hostname(_parsed_url->host());
         if (ssl_ca_pem)
           ((TLSSocket*)_socket)->set_root_ca_cert(ssl_ca_pem);
         else

--- a/libraries/SocketWrapper/src/utility/https_request.h
+++ b/libraries/SocketWrapper/src/utility/https_request.h
@@ -64,7 +64,7 @@ public:
         if (ssl_ca_pem)
           ((TLSSocket*)_socket)->set_root_ca_cert(ssl_ca_pem);
         else
-          ((TLSSocket*)_socket)->set_root_ca_cert_path("/wlan/");
+          ((TLSSocket*)_socket)->set_root_ca_cert_path("/wlan");
         _we_created_socket = true;
     }
 


### PR DESCRIPTION
Testing this [Sketch](https://github.com/arduino-libraries/Arduino_Portenta_OTA/blob/main/examples/OTA_Qspi_Flash/OTA_Qspi_Flash.ino) with ssl enabled turns out that:
* setting the hostname is necessary to complete the ssl handshake https://github.com/arduino/ArduinoCore-mbed/commit/0fb960e3431b8af3bfe330e4b5e78ca475a42577

* The cacert path is expanded with one exceeding slash `/wlan//cacert.pem` https://github.com/arduino/ArduinoCore-mbed/commit/367ca9cf4fb92969139fe27b54fcd83d132f58db . This is not a bug: the cacert is loaded correctly, but since i was there i've "fixed" the path expansion.