### PR TITLE
Make WiFiClientSSL class available

### DIFF
--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -197,6 +197,7 @@ public:
   friend class WiFiClient;
   friend class WiFiServer;
   friend class WiFiUDP;
+  friend class WiFiSSLClient;
 
   NetworkInterface* getNetwork();
 
@@ -221,5 +222,6 @@ extern WiFiClass WiFi;
 #include "WiFiClient.h"
 #include "WiFiServer.h"
 #include "WiFiUdp.h"
+#include "WiFiSSLClient.h"
 
 #endif


### PR DESCRIPTION
`WiFiSSLClient` was missing in `WiFi.h`, so examples using SSL fails to compile.

The SSL example was tested with the GIGA R1 WiFi board successfully.