### PR TITLE
nicla: Add missing return value in enterShipMode function.

### DIFF
--- a/libraries/Nicla_System/src/BQ25120A.h
+++ b/libraries/Nicla_System/src/BQ25120A.h
@@ -26,7 +26,7 @@ class BQ25120A
   BQ25120A() {};
 
   uint8_t getStatus();
-  void writeByte(uint8_t address, uint8_t subAddress, uint8_t data);
+  bool writeByte(uint8_t address, uint8_t subAddress, uint8_t data);
   uint8_t readByte(uint8_t address, uint8_t subAddress);
 
 };

--- a/libraries/Nicla_System/src/Nicla_System.cpp
+++ b/libraries/Nicla_System/src/Nicla_System.cpp
@@ -99,7 +99,7 @@ bool nicla::enterShipMode()
 
   uint8_t status_reg = _pmic.getStatus();
   status_reg |= 0x20;
-  _pmic.writeByte(BQ25120A_ADDRESS, BQ25120A_STATUS, status_reg);
+  return _pmic.writeByte(BQ25120A_ADDRESS, BQ25120A_STATUS, status_reg);
 }
 
 uint8_t nicla::readLDOreg()

--- a/libraries/Nicla_System/src/pmic_driver.cpp
+++ b/libraries/Nicla_System/src/pmic_driver.cpp
@@ -12,16 +12,17 @@ uint8_t BQ25120A::getStatus()
   return c;
 }
 
-void BQ25120A::writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
+bool BQ25120A::writeByte(uint8_t address, uint8_t subAddress, uint8_t data)
 {
   cd = 1;
   nicla::i2c_mutex.lock();
   Wire1.beginTransmission(address);
   Wire1.write(subAddress);
   Wire1.write(data);
-  Wire1.endTransmission();
+  uint8_t result = Wire1.endTransmission();
   nicla::i2c_mutex.unlock();
   cd = 0;
+  return result == 0;
 }
 
 uint8_t BQ25120A::readByte(uint8_t address, uint8_t subAddress)


### PR DESCRIPTION
An alternative solution to #635 which adds a missing return statement that leads to a compiler warning.

Thank you @alessandromrc for spotting this!