### PR TITLE
[Camera]  Fix a synchronization bug in example

### DIFF
--- a/libraries/Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
+++ b/libraries/Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
@@ -64,10 +64,12 @@ void loop() {
     while(!Serial);
   }
 
-  // Time out after 2 seconds and send new data
+  // Time out after 2 seconds, which sets the (constant) frame rate
   bool timeoutDetected = millis() - lastUpdate > 2000;
   
   // Wait for sync byte and timeout
+  // Notice that this order must be kept, or the sync bytes will be
+  // consumed prematurely
   if ((!timeoutDetected) || (Serial.read() != 1))
   {
     return;

--- a/libraries/Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
+++ b/libraries/Camera/examples/CameraCaptureRawBytes/CameraCaptureRawBytes.ino
@@ -67,8 +67,11 @@ void loop() {
   // Time out after 2 seconds and send new data
   bool timeoutDetected = millis() - lastUpdate > 2000;
   
-  // Wait for sync byte.
-  if(!timeoutDetected && Serial.read() != 1) return;  
+  // Wait for sync byte and timeout
+  if ((!timeoutDetected) || (Serial.read() != 1))
+  {
+    return;
+  }
 
   lastUpdate = millis();
   


### PR DESCRIPTION
Fixes a synchronization bug. Return if there's no timeout OR if there's no sync byte received. The previous version needed both to be true at the same time to return without sending a frame, which meant that a frame was sent if there was a timeout even if no sync byte had been received. That, in turn, caused random problems for the Processing sketch on the other end.