### PR TITLE
nicla-system: Enhance documentation for charging speed limits.

### DIFF
--- a/libraries/Nicla_System/src/Nicla_System.h
+++ b/libraries/Nicla_System/src/Nicla_System.h
@@ -98,9 +98,8 @@ public:
    * 
    * @param mA The desired milliampere (mA) charging current. Range: 5mA - 35mA and 40mA - 300mA. The default value is 20mA.
    * A safe default charging current value that works for most common LiPo batteries is 0.5C, which means charging at a rate equal to half of the battery's capacity.
-   * For example, a 200mAh battery could be charged at 100mA (0.1A).
+   * For example, a 200mAh battery could be safely charged at 100mA (0.1A).
    * This charging rate is generally safe for most LiPo batteries and provides a good balance between charging speed and battery longevity.
-   * @note If your battery doesn't have an NTC thermistor, the charging speed will be limited to ~16mA.
    * @note There is a saftey timer that will stop the charging after 3 hours by default. 
    * This can be configured by calling configureChargingSafetyTimer().
    * @return true If the fast charging is enabled successfully. False, otherwise.   


### PR DESCRIPTION
After further testing I realized I was using a battery that didn't work properly. Hence I removed the charging speed limitation note from the documentation.