### PR TITLE
Add udev rules for additional Mbed boards

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
-rp2040rules () {
+arduino_mbed_rules () {
     echo ""
-    echo "# Raspberry Pi RP2040 bootloader mode UDEV rules"
+    echo "# Arduino Mbed bootloader mode udev rules"
     echo ""
 cat <<EOF
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e8a", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0525", MODE:="0666"
 EOF
 }
 
@@ -14,7 +17,7 @@ if [ "$EUID" -ne 0 ]
   exit
 fi
 
-rp2040rules > /etc/udev/rules.d/60-rp2040.rules
+arduino_mbed_rules > /etc/udev/rules.d/60-arduino-mbed.rules
 
 # reload udev rules
 echo "Reload rules..."


### PR DESCRIPTION
The `post_install.sh` was apparently written specifically for the Nano RP2040 Connect, and does not set udev rules needed for the bootloader on (at least) these boards:

* GIGA R1 WiFi (mbed_giga)
* Nicla Sense ME (mbed_nicla)
* Portenta H7 (mbed_portenta)

Although these boards are initially discoverable, sketch upload will fail with a `Failed uploading: uploading error: exit status 74` message.

## Changes in this PR

* Update `post_install.sh` to add udev rules needed by GIGA R1 WiFi, Nicla Sense ME, and Portenta H7.
  * Most importantly, targetting the **2341** Vendor ID (Arduino).
  * Also targetting **1fc9** (NXP Semiconductors) and **0525** (PLX Technology), based on on [this documentation](https://docs.arduino.cc/tutorials/portenta-h7/setting-up-portenta#usb-hub-issues-troubleshooting).
* Change the name of the created file from `60-rp2040.rules` to `60-arduino-mbed.rules`.

## Tests

### Before running `post_install.sh` (missing udev rules)

#### GIGA R1 WiFi ❌

Upload fails:

```
dfu-util: Cannot open DFU device 2341:0366 found on devnum 24 (LIBUSB_ERROR_ACCESS)
dfu-util: No DFU capable USB device available
Failed uploading: uploading error: exit status 74
```

#### Nicla Sense ME ❌

Upload fails:

```
Error: unable to open CMSIS-DAP device 0x2341:0x60
Error: unable to find a matching CMSIS-DAP device

Failed uploading: uploading error: exit status 1
```

#### Portenta H7 ❌

Upload fails:

```
dfu-util: Cannot open DFU device 2341:035b found on devnum 27 (LIBUSB_ERROR_ACCESS)
dfu-util: No DFU capable USB device available
Failed uploading: uploading error: exit status 74
```

### After running `post_install.sh` (new udev rules added)

#### GIGA R1 WiFi ✅

Upload successful.

#### Nicla Sense ME ✅

Upload successful.

#### Portenta H7 ✅

Upload successful.