### PR TITLE
Make README clear about mbed-to-arduino script compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The repository contains the Arduino APIs and IDE integration files targeting a g
 
 ## Installation
 
+Note: 
+
 ### Clone the repository in `$sketchbook/hardware/arduino-git`
 
 ```bash
@@ -45,7 +47,7 @@ To install ARM build tools, use the `Boards Manager` option in the Arduino IDE t
 
 ## mbed-os-to-arduino script
 
-The backbone of the packaging process is the https://github.com/arduino/ArduinoCore-mbed/blob/master/mbed-os-to-arduino script. It basically compiles a blank Mbed OS project for any supported target board, recovering the files that will be needed at compile time and copying them to the right location.
+The backbone of the packaging process is the https://github.com/arduino/ArduinoCore-mbed/blob/master/mbed-os-to-arduino script. It basically compiles a blank Mbed OS project for any supported target board, recovering the files that will be needed at compile time and copying them to the right location. This script is not compatible with MacOS, it must be run on Linux.
 
 It can be used for a variety of tasks including:
 


### PR DESCRIPTION
It would be nice if the readme specified that the `mbed-os-to-arduino` script is not compatible with MacOS, and has to be run on a Linux system.

According to @facchinm in #87 the script was not compatible as of 2020, and after trying it out on MacOS today it is still not working because of the `declare -A` command being different in MacOS than on Linux.