### PR TITLE
Add guard for pin in range in pinMode

### DIFF
--- a/cores/arduino/wiring_digital.cpp
+++ b/cores/arduino/wiring_digital.cpp
@@ -51,6 +51,9 @@ void pinMode(PinName pin, PinMode mode)
 
 void pinMode(pin_size_t pin, PinMode mode)
 {
+  if (pin >= PINS_COUNT) {
+    return;
+  }
   mbed::DigitalInOut* gpio = digitalPinToGpio(pin);
   if (gpio != NULL) {
     delete gpio;


### PR DESCRIPTION
Fix #693

The [`pinMode(pin_size_t pin, PinMode mode)`](https://github.com/arduino/ArduinoCore-mbed/blob/main/cores/arduino/wiring_digital.cpp#L52) function can be passed a pin number that is out of range, crashing the microcontroller. This PR adds the same test found in [`digitalWrite(pin_size_t pin, PinStatus val)`](https://github.com/arduino/ArduinoCore-mbed/blob/main/cores/arduino/wiring_digital.cpp#L91) and [`digitalRead(pin_size_t pin)`](https://github.com/arduino/ArduinoCore-mbed/blob/main/cores/arduino/wiring_digital.cpp#L114) to ensure that the pin is in range.