### PR TITLE
[AE-124] [PROBUPOC-694] Enable D15-D18 to reference digital pins on the Opta

### DIFF
--- a/variants/OPTA/pins_arduino.h
+++ b/variants/OPTA/pins_arduino.h
@@ -85,10 +85,10 @@ static const uint8_t A7  = PIN_A7;
 #define D12 (12u)
 #define D13 (13u)
 #define D14 (14u)
-#define D15 #error Pin cannot be used as digital pin.
-#define D16 #error Pin cannot be used as digital pin.
-#define D17 #error Pin cannot be used as digital pin.
-#define D18 #error Pin cannot be used as digital pin.
+#define D15 (15u)
+#define D16 (16u)
+#define D17 (17u)
+#define D18 (18u)
 #define D19 (19u)
 #define D20 (20u)
 #define D21 (21u)


### PR DESCRIPTION
Referencing pins D15 to D18 on the Opta leads to a `Pin cannot be used as digital pin` error. This is traced to the following lines in [pins_arduino.h](https://github.com/arduino/ArduinoCore-mbed/blob/main/variants/OPTA/pins_arduino.h).
https://github.com/arduino/ArduinoCore-mbed/blob/aef18a14398de1a7871d49a7de63fcb5d3643818/variants/OPTA/pins_arduino.h#L88-L91

This PR allows for D15, D16, D17 and D18 to be used within Arduino sketches on the Opta by defining them accordingly. 
![image](https://github.com/arduino/ArduinoCore-mbed/assets/75624145/16ff0555-e001-48ea-96ec-6ce4fdd0600d)
