### PR TITLE
post_install.sh: Use uaccess tag in udev rules

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
 arduino_mbed_rules () {
-    echo ""
-    echo "# Arduino Mbed bootloader mode udev rules"
-    echo ""
 cat <<EOF
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e8a", MODE:="0666"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", MODE:="0666"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", MODE:="0666"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0525", MODE:="0666"
+
+# Arduino Mbed bootloader mode udev rules
+
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e8a", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0525", TAG+="uaccess"
 EOF
 }
 
-if [ "$EUID" -ne 0 ]
-  then echo "Please run as root"
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root"
   exit
 fi
 


### PR DESCRIPTION
Do not make device node world-writeable, instead give access to desktop user.

Also use one "here" document instead of mixing in echo statements. Customarily keep "then" on same line as "if".