### PR TITLE
Create library.json

### DIFF
--- a/libraries/rpclib/library.json
+++ b/libraries/rpclib/library.json
@@ -1,0 +1,7 @@
+{
+    "name": "rpclib",
+    "version": "1.0.0",
+    "build": {
+      "srcFilter": "+<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/> -<**/*.cc>"
+    }
+  }


### PR DESCRIPTION
prevent .cc compilation to fix asio.hpp not found when using RPC.h

fixed error like in this discussion

https://community.platformio.org/t/portenta-and-rpc-missing-asio-hpp-header-framework-arduino-mbed-not-latest/26862/4