### PR TITLE
MbedSSLClient - remove unnecessary dependecy to specific BlockDevice

### DIFF
--- a/libraries/SocketWrapper/src/MbedSSLClient.h
+++ b/libraries/SocketWrapper/src/MbedSSLClient.h
@@ -23,7 +23,6 @@
 #include "MbedClient.h"
 #include <FATFileSystem.h>
 #include <MBRBlockDevice.h>
-#include <QSPIFBlockDevice.h>
 
 extern const char CA_CERTIFICATES[];
 
@@ -58,7 +57,7 @@ private:
   int setRootCA() {
     mbed::BlockDevice* root = mbed::BlockDevice::get_default_instance();
     int err = root->init();
-    if( err != QSPIF_BD_ERROR_OK) {
+    if( err != 0) {
       return err;
     }
 


### PR DESCRIPTION
the include for the include of QSPIFBlockDevice.h for constant QSPIF_BD_ERROR_OK with value 0 is unnecessary and creates an unnecessary compile dependency.

The doc for BlockDevice::init has
```
    /** Initialize a block device
     *
     *  @return         0 on success or a negative error code on failure
     */
```
so it is OK to compare the return value to 0.