### PR TITLE
Ethernet - apply MAC address in begin(mac)

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -9,6 +9,10 @@ int arduino::EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned 
     if (eth_if == nullptr) return 0;
   }
 
+  if (mac != nullptr) {
+    eth_if->get_emac().set_hwaddr(mac);
+  }
+
   unsigned long start = millis();
   eth_if->set_blocking(false);
   eth_if->connect();


### PR DESCRIPTION
apply MAC address in Ethernet.begin(mac)

tested with "ENC28J60 Mbed EMAC" and "Nano 33 BLE"

https://github.com/JAndrassy/ENC28J60-EMAC