### PR TITLE
Add macAddress() getter

### DIFF
--- a/libraries/SocketWrapper/src/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/src/SocketHelpers.cpp
@@ -11,6 +11,10 @@ uint8_t* arduino::MbedSocketClass::macAddress(uint8_t* mac) {
   return mac;
 }
 
+String arduino::MbedSocketClass::macAddress() {
+  return String(getNetwork()->get_mac_address());
+}
+
 int arduino::MbedSocketClass::hostByName(const char* aHostname, IPAddress& aResult) {
   SocketAddress socketAddress = SocketAddress();
   nsapi_error_t returnCode = getNetwork()->gethostbyname(aHostname, &socketAddress);

--- a/libraries/SocketWrapper/src/SocketHelpers.h
+++ b/libraries/SocketWrapper/src/SocketHelpers.h
@@ -106,6 +106,7 @@ public:
   int hostByName(const char* aHostname, IPAddress& aResult);
 
   uint8_t* macAddress(uint8_t* mac);
+  String macAddress();
 
   void setFeedWatchdogFunc(voidFuncPtr func);
   void feedWatchdog();


### PR DESCRIPTION
This PR adds a new signature for macAddress:

```
String macAddress();
```

This signature is already present in ESP32, so adding it to this core will increase the interoperability with sketches and libraries developed for ESP32.