### PR TITLE
Add WiFiServer::accept() as alias to WiFiServer::available()

### DIFF
--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -15,3 +15,7 @@ arduino::WiFiClient arduino::WiFiServer::available(uint8_t* status) {
   }
   return client;
 }
+
+arduino::WiFiClient arduino::WiFiServer::accept() {
+  return available();
+}

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -34,6 +34,7 @@ public:
   WiFiServer(uint16_t port)
     : MbedServer(port) {}
   WiFiClient available(uint8_t* status = nullptr);
+  WiFiClient accept();
 };
 
 }


### PR DESCRIPTION
Since `available()` is currently implemented as `accept()` (i.e. it returns a client even before it has actually sent any data), we provide an alias for it.