### PR TITLE
Add WiFiServer::stop() and WiFiServer::end()

### DIFF
--- a/libraries/SocketWrapper/src/MbedServer.h
+++ b/libraries/SocketWrapper/src/MbedServer.h
@@ -41,13 +41,15 @@ public:
   MbedServer(uint16_t port)
     : _port(port){};
 
-  virtual ~MbedServer() {
+  virtual ~MbedServer() { end(); }
+  void begin();
+  void end() {
     if (sock) {
       delete sock;
       sock = nullptr;
     }
-  }
-  void begin();
+  };
+  void stop() { end(); };
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   uint8_t status();


### PR DESCRIPTION
This PR adds an `end()` method (aliased to `stop()` for better interoperability) which is symmetric to `begin()`. This is borrowed by the ESP8266 and ESP32 cores.