### PR TITLE
Improve reliability of the Callback implementation

### DIFF
--- a/cores/arduino/mbed/platform/include/platform/Callback.h
+++ b/cores/arduino/mbed/platform/include/platform/Callback.h
@@ -17,6 +17,11 @@
 #ifndef MBED_CALLBACK_H
 #define MBED_CALLBACK_H
 
+// This prevents the GCC compiler from applying optimizations that assume the code follows strict aliasing rules.
+// In order to prevent bugs arising from undefined behavior that is tricky to find in the Callback implementation,
+// or simply from compiler bugs in GCC.
+#pragma GCC optimize("-fno-strict-aliasing")
+
 #include <cstring>
 #include <mstd_cstddef>
 #include <stdint.h>

--- a/cores/arduino/mbed/platform/include/platform/Callback.h
+++ b/cores/arduino/mbed/platform/include/platform/Callback.h
@@ -17,11 +17,6 @@
 #ifndef MBED_CALLBACK_H
 #define MBED_CALLBACK_H
 
-// This prevents the GCC compiler from applying optimizations that assume the code follows strict aliasing rules.
-// In order to prevent bugs arising from undefined behavior that is tricky to find in the Callback implementation,
-// or simply from compiler bugs in GCC.
-#pragma GCC optimize("-fno-strict-aliasing")
-
 #include <cstring>
 #include <mstd_cstddef>
 #include <stdint.h>
@@ -30,6 +25,14 @@
 #include "platform/mbed_toolchain.h"
 #include <mstd_type_traits>
 #include <mstd_functional>
+
+#pragma GCC push_options
+// This prevents the GCC compiler from applying optimizations that assume the code follows strict aliasing rules.
+// In order to prevent bugs arising from undefined behavior that is tricky to find in the Callback implementation,
+// or simply from compiler bugs in GCC.
+#pragma GCC optimize("-fno-strict-aliasing")
+// This prevents the GCC compiler from generating incorrect inline code for the Callback constructor.
+#pragma GCC optimize("-fno-inline")
 
 // Controlling switches from config:
 // MBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL - support storing non-trivial function objects
@@ -40,7 +43,6 @@
 #undef MBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL
 #define MBED_CONF_PLATFORM_CALLBACK_NONTRIVIAL 1
 #endif
-
 
 namespace mbed {
 /** \addtogroup platform-public-api */
@@ -839,5 +841,7 @@ Callback(R(*func)(const volatile T *, ArgTs...), const volatile U *arg) -> Callb
 /**@}*/
 
 } // namespace mbed
+
+#pragma GCC pop_options
 
 #endif


### PR DESCRIPTION
These changes are made since some combinations of code and compiler versions sometimes lead to erroneous machine code being generated, because of the somewhat adventurous implementation in Callback.h. The first change prevents the GCC compiler from applying optimizations that assume the code follows strict aliasing rules. The second one prevents the GCC compiler from sometimes generating incorrect inline code for the Callback constructor. The machine code generated with these changes are, on the one hand, less optimal. But on the other hand, the changes should prevent bugs arising from undefined behavior that is tricky to find in the Callback implementation, or simply from compiler bugs in GCC. The philosophy here is that it's better to be safe than sorry, rather than trying to find and fix every single dangerous construct in the code.

See also this post from a few years ago by one of the authors of Callback.h: https://answers.launchpad.net/gcc-arm-embedded/+question/686870