### PR TITLE
Add include guard to pinDefinitions.h to avoid double inclusion issue

### DIFF
--- a/cores/arduino/pinDefinitions.h
+++ b/cores/arduino/pinDefinitions.h
@@ -1,3 +1,6 @@
+#ifndef PIN_DEFINITIONS_H
+#define PIN_DEFINITIONS_H
+
 #ifdef USE_ARDUINO_PINOUT
 
 #include "drivers/InterruptIn.h"
@@ -36,4 +39,6 @@ PinName digitalPinToPinName(pin_size_t P);
 
 int PinNameToIndex(PinName P);
 
-#endif
+#endif // USE_ARDUINO_PINOUT
+
+#endif // PIN_DEFINITIONS_H


### PR DESCRIPTION
Add include guard to `pinDefinitions.h` header file to avoid double inclusion issue