### PR TITLE
SocketWrapper: avoid Stream setTimeout shadowing

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -310,6 +310,6 @@ uint16_t arduino::MbedClient::remotePort() {
   return address.get_port();
 }
 
-void arduino::MbedClient::setTimeout(unsigned long timeout) {
+void arduino::MbedClient::setSocketTimeout(unsigned long timeout) {
   _timeout = timeout;
 }

--- a/libraries/SocketWrapper/src/MbedClient.h
+++ b/libraries/SocketWrapper/src/MbedClient.h
@@ -97,7 +97,7 @@ public:
   IPAddress remoteIP();
   uint16_t remotePort();
 
-  void setTimeout(unsigned long timeout);
+  void setSocketTimeout(unsigned long timeout);
 
   friend class MbedServer;
   friend class MbedSSLClient;


### PR DESCRIPTION
Shoould fix #728 