### PR TITLE
GSM: do not check for __has_include in library main include

### DIFF
--- a/libraries/GSM/src/GSM.cpp
+++ b/libraries/GSM/src/GSM.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "GSM.h"
+#include "GSMDebug.h"
 
 #include "mbed.h"
 #include "CellularLog.h"

--- a/libraries/GSM/src/GSM.h
+++ b/libraries/GSM/src/GSM.h
@@ -63,27 +63,6 @@
   #endif
 #endif
 
-#if defined __has_include
-  #if __has_include ("Arduino_DebugUtils.h")
-    #include "Arduino_DebugUtils.h"
-    #define GSM_DEBUG_ENABLE 1
-  #else
-    #define DEBUG_ERROR(fmt, ...)
-    #define DEBUG_WARNING(fmt, ...)
-    #define DEBUG_INFO(fmt, ...)
-    #define DEBUG_DEBUG(fmt, ...)
-    #define DEBUG_VERBOSE(fmt, ...)
-    #define GSM_DEBUG_ENABLE 0
-  #endif
-#else
-    #define DEBUG_ERROR(fmt, ...)
-    #define DEBUG_WARNING(fmt, ...)
-    #define DEBUG_INFO(fmt, ...)
-    #define DEBUG_DEBUG(fmt, ...)
-    #define DEBUG_VERBOSE(fmt, ...)
-    #define GSM_DEBUG_ENABLE 0
-#endif
-
 namespace arduino {
 
 typedef void* (*voidPrtFuncPtr)(void);
@@ -159,7 +138,6 @@ private:
    */
   const uint16_t _retry_timeout[6] = {1, 2, 4, 8, 16, 32};
 
-#if GSM_DEBUG_ENABLE
   static constexpr int RSSI_UNKNOWN = 99;
   static const char * const sim_state_str[];
   static const char * const reg_type_str[];
@@ -172,7 +150,7 @@ private:
   static const char * getSIMStateString(const mbed::CellularDevice::SimState state);
   static const char * getRegistrationStateString(const mbed::CellularNetwork::RegistrationStatus state);
   void onStatusChange(nsapi_event_t ev, intptr_t in);
-#endif
+
   void reset();
   bool isReady(const int timeout = 5000);
 };

--- a/libraries/GSM/src/GSMDebug.cpp
+++ b/libraries/GSM/src/GSMDebug.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <GSM.h>
+#include <GSMDebug.h>
 
 #if GSM_DEBUG_ENABLE
 

--- a/libraries/GSM/src/GSMDebug.h
+++ b/libraries/GSM/src/GSMDebug.h
@@ -1,0 +1,44 @@
+/*
+  GSMDebug.h
+  Copyright (c) 2021 Arduino SA.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef GSMDEBUG_H
+#define GSMDEBUG_H
+
+#if defined __has_include
+  #if __has_include ("Arduino_DebugUtils.h")
+    #include "Arduino_DebugUtils.h"
+    #define GSM_DEBUG_ENABLE 1
+  #else
+    #define DEBUG_ERROR(fmt, ...)
+    #define DEBUG_WARNING(fmt, ...)
+    #define DEBUG_INFO(fmt, ...)
+    #define DEBUG_DEBUG(fmt, ...)
+    #define DEBUG_VERBOSE(fmt, ...)
+    #define GSM_DEBUG_ENABLE 0
+  #endif
+#else
+    #define DEBUG_ERROR(fmt, ...)
+    #define DEBUG_WARNING(fmt, ...)
+    #define DEBUG_INFO(fmt, ...)
+    #define DEBUG_DEBUG(fmt, ...)
+    #define DEBUG_VERBOSE(fmt, ...)
+    #define GSM_DEBUG_ENABLE 0
+#endif
+
+#endif /* GSMDEBUG_H*/


### PR DESCRIPTION
  * This can break library discovery and should be avoided