### PR TITLE
Ethernet.h remove unimplemented methods

### DIFF
--- a/libraries/Ethernet/src/Ethernet.h
+++ b/libraries/Ethernet/src/Ethernet.h
@@ -91,8 +91,6 @@ public:
 
   void MACAddress(uint8_t *mac_address);
 
-  void setHostname(const char *name);
-
   int disconnect(void);
   void end(void);
 
@@ -123,7 +121,6 @@ private:
   EthernetInterface *eth_if = &net;
   voidPrtFuncPtr _initializerCallback;
   arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
-  SocketAddress socketAddressFromIpAddress(arduino::IPAddress ip, uint16_t port);
 };
 
 }


### PR DESCRIPTION
* socketAddressFromIpAddress is  the base class 
* setHostname causes linker error. implementation is not possible