### PR TITLE
fix ADC management for pure analog on GIGA

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -84,6 +84,7 @@ typedef struct _AnalogPinDescription AnalogPinDescription;
 extern PinDescription g_APinDescription[];
 extern AnalogPinDescription g_AAnalogPinDescription[];
 extern AnalogPinDescription g_AAnalogOutPinDescription[];
+extern AnalogPinDescription g_pureAAnalogPinDescription[];
 
 #ifdef ANALOG_CONFIG
 #include "hal/analogin_api.h"

--- a/variants/GIGA/pins_arduino.h
+++ b/variants/GIGA/pins_arduino.h
@@ -20,7 +20,7 @@ extern PinName digitalPinToPinName(pin_size_t P);
 // ----
 #define PINS_COUNT           (PINCOUNT_fn())
 #define NUM_DIGITAL_PINS     (103u)
-#define NUM_ANALOG_INPUTS    (14u)
+#define NUM_ANALOG_INPUTS    (10u) // these are analog pins that can also be used as digital
 #define NUM_ANALOG_OUTPUTS   (2u)
 
 // LEDs

--- a/variants/GIGA/pure_analog_pins.cpp
+++ b/variants/GIGA/pure_analog_pins.cpp
@@ -2,19 +2,20 @@
 #include "AnalogIn.h"
 #include "pinDefinitions.h"
 
-PureAnalogPin  A8(8);
-PureAnalogPin  A9(9);
-PureAnalogPin  A10(10);
-PureAnalogPin  A11(11);
+PureAnalogPin  A8(0);
+PureAnalogPin  A9(1);
+PureAnalogPin  A10(2);
+PureAnalogPin  A11(3);
+
 
 int getAnalogReadResolution();
 
 int analogRead(PureAnalogPin pin) {
-  mbed::AnalogIn* adc = g_AAnalogPinDescription[pin.get()].adc;
-  auto name = g_AAnalogPinDescription[pin.get()].name;
+  mbed::AnalogIn* adc = g_pureAAnalogPinDescription[pin.get()].adc;
+  auto name = g_pureAAnalogPinDescription[pin.get()].name;
   if (adc == NULL) {
     adc = new mbed::AnalogIn(name);
-    g_AAnalogPinDescription[pin.get()].adc = adc;
+    g_pureAAnalogPinDescription[pin.get()].adc = adc;
   }
   return (adc->read_u16() >> (16 - getAnalogReadResolution()));
 }

--- a/variants/GIGA/variant.cpp
+++ b/variants/GIGA/variant.cpp
@@ -12,12 +12,15 @@ AnalogPinDescription g_AAnalogPinDescription[] = {
   { PC_2,         NULL },    // A5   ADC1_INP12
   { PC_0,         NULL },    // A6   ADC1_INP10
   { PA_0,         NULL },    // A7   ADC1_INP16
+  { PA_4,         NULL },    // A12  DAC1_OUT1
+  { PA_5,         NULL },    // A13  DAC1_OUT2
+};
+
+AnalogPinDescription g_pureAAnalogPinDescription[] = {
   { PC_2C,        NULL },    // A8   ADC3_INP0
   { PC_3C,        NULL },    // A9   ADC3_INP1
   { PA_1C,        NULL },    // A10  ADC2_INP1
   { PA_0C,        NULL },    // A11  ADC2_INP0
-  { PA_4,         NULL },    // A12  DAC1_OUT1
-  { PA_5,         NULL },    // A13  DAC1_OUT2
 };
 
 AnalogPinDescription g_AAnalogOutPinDescription[] = {


### PR DESCRIPTION
This PR allows to fix the management of the pure analogs on GIGA, the issue was that the pure analog pins have not been considered on the **g_APinDescription** array, this results on miss an offset of 4 elements when a **g_AAnalogPinDescription's pin** was select in the **analogRead()** in **wiring_Analog.cpp**.
The consequence is that the macros involved in Pin and ADC selection, could potentially identify an ADC assigned to the pure analog pins as the ADC channel for all those analog listed after the pin A11 in **g_AAnalogPinDescription array** in the **variant.cpp** and than read the ADC channel of the pure analog pins instead of the correct one (e. g. A8 for A12, A9 for A13 and so on and so forth).

The Fix split the two kind of analog pin in order that the correct offset is provided during reading time and manage the pure analog and the other analogs pin as a different entities inside the pins management.

This PR fixes https://github.com/arduino/ArduinoCore-mbed/issues/758
