### PR TITLE
Socket download function improvements

### DIFF
--- a/libraries/SocketWrapper/src/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/src/SocketHelpers.cpp
@@ -125,7 +125,7 @@ void MbedSocketClass::feedWatchdog() {
 
 void MbedSocketClass::body_callback(const char* data, uint32_t data_len) {
   feedWatchdog();
-  fwrite(data, 1, data_len, download_target);
+  fwrite(data, sizeof(data[0]), data_len, download_target);
 }
 
 int MbedSocketClass::download(char* url, const char* target_file, bool const is_https) {

--- a/libraries/SocketWrapper/src/SocketHelpers.h
+++ b/libraries/SocketWrapper/src/SocketHelpers.h
@@ -107,8 +107,24 @@ public:
   IPAddress dnsIP(int n = 0);
 
   virtual NetworkInterface* getNetwork() = 0;
-
-  int download(char* url, const char* target, bool const is_https = false);
+  
+  /*
+     * Download a file from an HTTP endpoint and save it in the provided `target` location on the fs
+     * The parameter cbk can be used to perform actions on the buffer before saving on the fs
+     *
+     * return: on success the size of the downloaded file, on error -status code
+     */
+  int download(
+    const char* url, const char* target, bool const is_https = false);
+  /*
+     * Download a file from an HTTP endpoint and handle the body of the request on a callback
+     * passed as an argument
+     *
+     * return: on success the size of the downloaded file, on error -status code
+     */
+  int download(
+    const char* url, bool const is_https = false,
+    mbed::Callback<void(const char*, uint32_t)> cbk = nullptr);
 
   int hostByName(const char* aHostname, IPAddress& aResult);
 


### PR DESCRIPTION
In this PR I split the download function into 2 versions:
- version 1: the old one that downloads a file and stores it on the fs
- version 2: download a file and allow the user to specify a callback to handle the incoming body buffer
This is required to perform LZSS decompression on the fly