### PR TITLE
Ethernet - allow return to DHCP after `begin` with static IP

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -8,7 +8,11 @@ int arduino::EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned 
     _initializerCallback();
     if (eth_if == nullptr) return 0;
   }
+  eth_if->set_dhcp(true);
+  _begin(mac, timeout, responseTimeout);
+}
 
+int arduino::EthernetClass::_begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout) {
   if (mac != nullptr) {
     eth_if->get_emac().set_hwaddr(mac);
   }
@@ -53,7 +57,7 @@ int arduino::EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPA
   eth_if->set_network(_ip, _netmask, _gateway);
   eth_if->add_dns_server(_dnsServer1, nullptr);
 
-  auto ret = begin(mac, timeout, responseTimeout);
+  auto ret = _begin(mac, timeout, responseTimeout);
   return ret;
 }
 

--- a/libraries/Ethernet/src/Ethernet.h
+++ b/libraries/Ethernet/src/Ethernet.h
@@ -116,6 +116,8 @@ public:
   constexpr static int maintain () { return DHCP_CHECK_NONE; }
 
 private:
+  int _begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout);
+
   volatile EthernetLinkStatus _currentNetworkStatus = Unknown;
   EthernetInterface net;
   EthernetInterface *eth_if = &net;


### PR DESCRIPTION
the `begin` for DHCP didn't set dhcp to true. the same function was used internally from `begin` for static IP. 
this PR separates a private `_begin` from `begin` for DHCP and sets dhcp to true in the public `begin` for DHCP.

tested with [LegacyEthernetTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/LegacyEthernetTest/LegacyEthernetTest.ino)