### PR TITLE
Avoid warning about missing return

### DIFF
--- a/variants/OPTA/variant.cpp
+++ b/variants/OPTA/variant.cpp
@@ -253,7 +253,7 @@ class SecureQSPIFBlockDevice: public QSPIFBlockDevice {
 
 #if 1
 // 256byte secure OTP area (on AT25SF128A)
-// TODO: could be imcomplete, to be tested
+// TODO: could be incomplete, to be tested
 class SecureQSPIFBlockDevice: public QSPIFBlockDevice {
   public:
     virtual int readSecure(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size) {

--- a/variants/OPTA/variant.cpp
+++ b/variants/OPTA/variant.cpp
@@ -263,9 +263,15 @@ class SecureQSPIFBlockDevice: public QSPIFBlockDevice {
     }
     virtual int programSecure(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size) {
       // like normal program with 42h
+    
+      // avoid warning: no return statement in function returning non-void [-Wreturn-type]
+      return 0;
     }
     virtual int eraseSecure(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size) {
       // like normal program with 44h
+    
+      // avoid: warning: no return statement in function returning non-void [-Wreturn-type]
+      return 0;
     }
 };
 #endif


### PR DESCRIPTION
When compiling a sketch with Mbed OPTA board selected, you get the following warning, if you have enabled *All* compiler warnings.

```
/home/simon/.arduino15/packages/arduino/hardware/mbed_opta/4.0.10/variants/OPTA/variant.cpp: In member function 'virtual int SecureQSPIFBlockDevice::programSecure(void*, mbed::bd_addr_t, mbed::bd_size_t)':
/home/simon/.arduino15/packages/arduino/hardware/mbed_opta/4.0.10/variants/OPTA/variant.cpp:266:5: warning: no return statement in function returning non-void [-Wreturn-type]
     }
     ^
/home/simon/.arduino15/packages/arduino/hardware/mbed_opta/4.0.10/variants/OPTA/variant.cpp: In member function 'virtual int SecureQSPIFBlockDevice::eraseSecure(void*, mbed::bd_addr_t, mbed::bd_size_t)':
/home/simon/.arduino15/packages/arduino/hardware/mbed_opta/4.0.10/variants/OPTA/variant.cpp:269:5: warning: no return statement in function returning non-void [-Wreturn-type]
     }
     ^
```

To remove this warning there are 2 options:
1. Return some value
2. Use GCC `#pragma` directive to turn off warnings temporarily

I chose the first option, but a comment right above the class says `// 256byte secure OTP area (on AT25SF128A)`, and I'm not sure if this means that the class/function definitions will produce too large outputs (>256). In which case, option 2 should be used instead IMO.