### PR TITLE
overwrite launch request with attach one

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -168,6 +168,7 @@ envie_m7.bootloader.file=PORTENTA_H7/portentah7_bootloader_mbed_hs_v2.elf
 envie_m7.debug.server.openocd.scripts.0=interface/{programmer.protocol}.cfg
 envie_m7.debug.server.openocd.scripts.1={programmer.transport_script}
 envie_m7.debug.server.openocd.scripts.2=target/stm32h7x_dual_bank.cfg
+envie_m7.debug.cortex-debug.custom.request=attach
 envie_m7.menu.target_core.cm7.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM7.svd
 envie_m7.menu.target_core.cm4.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM4.svd
 
@@ -606,6 +607,7 @@ nicla_vision.bootloader.file=NICLA_VISION/bootloader.elf
 nicla_vision.debug.server.openocd.scripts.0=interface/{programmer.protocol}.cfg
 nicla_vision.debug.server.openocd.scripts.1={programmer.transport_script}
 nicla_vision.debug.server.openocd.scripts.2=target/stm32h7x_dual_bank.cfg
+nicla_vision.debug.cortex-debug.custom.request=attach
 nicla_vision.menu.target_core.cm7.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM7.svd
 nicla_vision.menu.target_core.cm4.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM4.svd
 
@@ -741,6 +743,7 @@ opta.bootloader.file=OPTA/bootloader.elf
 opta.debug.server.openocd.scripts.0=interface/{programmer.protocol}.cfg
 opta.debug.server.openocd.scripts.1={programmer.transport_script}
 opta.debug.server.openocd.scripts.2=target/stm32h7x_dual_bank.cfg
+opta.debug.cortex-debug.custom.request=attach
 opta.menu.target_core.cm7.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM7.svd
 opta.menu.target_core.cm4.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM4.svd
 
@@ -843,5 +846,6 @@ giga.bootloader.file=GIGA/bootloader.elf
 giga.debug.server.openocd.scripts.0=interface/{programmer.protocol}.cfg
 giga.debug.server.openocd.scripts.1={programmer.transport_script}
 giga.debug.server.openocd.scripts.2=target/stm32h7x_dual_bank.cfg
+giga.debug.cortex-debug.custom.request=attach
 giga.menu.target_core.cm7.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM7.svd
 giga.menu.target_core.cm4.debug.svd_file={runtime.platform.path}/svd/STM32H747_CM4.svd


### PR DESCRIPTION
For some reason, `lauch` openOCD request causes the gdb-server to fail with:
```
xPSR: 0x01000003 pc: 0x3f081a3e msp: 0x2407ff88
Error: error reading data: (null)
Error: CMSIS-DAP command mismatch. Sent 0x3 received 0x5
Error: CMSIS-DAP command CMD_DISCONNECT failed.
Info : SWD DPIDR 0x6ba02477
Error: Failed to read memory at 0xe00e1008
Error: mem2array: Read @ 0xe00e1004, w=4, cnt=1, failed
Error executing event examine-end on target stm32h7x.cpu0:
/home/umberto/.arduino15/packages/arduino/tools/openocd/0.11.0-arduino2/bin/../share/openocd/scripts/target/stm32h7x.cfg:236: Error: 
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 260
in procedure 'stm32h7x_dbgmcu_mmw' called at file "/home/umberto/.arduino15/packages/arduino/tools/openocd/0.11.0-arduino2/bin/../share/openocd/scripts/target/stm32h7x.cfg", line 172
in procedure 'stm32h7x_mmw' called at file "/home/umberto/.arduino15/packages/arduino/tools/openocd/0.11.0-arduino2/bin/../share/openocd/scripts/target/stm32h7x.cfg", line 260
in procedure 'stm32h7x_mrw' called at file "/home/umberto/.arduino15/packages/arduino/tools/openocd/0.11.0-arduino2/bin/../share/openocd/scripts/target/stm32h7x.cfg", line 242
at file "/home/umberto/.arduino15/packages/arduino/tools/openocd/0.11.0-arduino2/bin/../share/openocd/scripts/target/stm32h7x.cfg", line 236
target halted due to debug-request, current mode: Handler HardFault
xPSR: 0x01000003 pc: 0x3f081a3e msp: 0x2407ff88
shutdown command invoked
[2023-12-20T11:55:49.834Z] SERVER CONSOLE DEBUG: onBackendConnect: gdb-server session closed
GDB server session ended. This terminal will be reused, waiting for next session to start...
```
With this patch, everything seems to be working just fine (tested only on GIGA but ported to every STM32H7). Pressing the "start debug" button after uploading does not require the board to be put in bootloader mode.