### PR TITLE
Fix DNS get methods

### DIFF
--- a/libraries/SocketWrapper/src/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/src/SocketHelpers.cpp
@@ -50,14 +50,18 @@ arduino::IPAddress arduino::MbedSocketClass::gatewayIP() {
 arduino::IPAddress arduino::MbedSocketClass::dnsServerIP() {
   SocketAddress ip;
   NetworkInterface* interface = getNetwork();
-  interface->get_dns_server(0, &ip, nullptr);
+  char _if_name[5] {};
+  interface->get_interface_name(_if_name);
+  interface->get_dns_server(0, &ip, _if_name);
   return ipAddressFromSocketAddress(ip);
 }
 
 arduino::IPAddress arduino::MbedSocketClass::dnsIP(int n) {
   SocketAddress ip;
   NetworkInterface* interface = getNetwork();
-  interface->get_dns_server(n, &ip, nullptr);
+  char _if_name[5] {};
+  interface->get_interface_name(_if_name);
+  interface->get_dns_server(n, &ip, _if_name);
   return ipAddressFromSocketAddress(ip);
 }
 


### PR DESCRIPTION
This PR fixes the `::dnsServerIP()` and  `::dnsIP()` methods to retrieve the DNS server configuration properly.

The issue is due to [NetworkInterface.cpp#L111-L112](https://github.com/manchoz/mbed-os/blob/f6d6cdfcefc77d0bf333cf60812a1d0b7282a5f5/connectivity/netsocket/source/NetworkInterface.cpp#L111-L112) ultimately requiring the interface name because of [lwip_dns.c#L505-L506](https://github.com/manchoz/mbed-os/blob/f6d6cdfcefc77d0bf333cf60812a1d0b7282a5f5/connectivity/lwipstack/lwip/src/core/lwip_dns.c#L505-L506)