### PR TITLE
WiFi - add missing scan result getter implementations (BSSID, channel) and the ScanNetworksAdvanced example

### DIFF
--- a/libraries/WiFi/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
+++ b/libraries/WiFi/examples/ScanNetworksAdvanced/ScanNetworksAdvanced.ino
@@ -1,0 +1,132 @@
+/*
+  This example  prints the board's MAC address, and
+  scans for available WiFi networks using the NINA module.
+  Every ten seconds, it scans again. It doesn't actually
+  connect to any network, so no encryption scheme is specified.
+  BSSID and WiFi channel are printed
+
+  This example is based on ScanNetworks
+
+  created 1 Mar 2017
+  by Arturo Guadalupi
+*/
+
+
+
+#include <WiFi.h>
+
+void setup() {
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+
+  // check for the WiFi module:
+  if (WiFi.status() == WL_NO_MODULE) {
+    Serial.println("Communication with WiFi module failed!");
+    // don't continue
+    while (true);
+  }
+
+  // scan for existing networks:
+  Serial.println();
+  Serial.println("Scanning available networks...");
+  listNetworks();
+
+  // print your MAC address:
+  byte mac[6];
+  WiFi.macAddress(mac);
+  Serial.print("MAC: ");
+  printMacAddress(mac);
+}
+
+void loop() {
+  delay(10000);
+  // scan for existing networks:
+  Serial.println("Scanning available networks...");
+  listNetworks();
+}
+
+void listNetworks() {
+  // scan for nearby networks:
+  Serial.println("** Scan Networks **");
+  int numSsid = WiFi.scanNetworks();
+  if (numSsid == -1)
+  {
+    Serial.println("Couldn't get a WiFi connection");
+    while (true);
+  }
+
+  // print the list of networks seen:
+  Serial.print("number of available networks: ");
+  Serial.println(numSsid);
+
+  // print the network number and name for each network found:
+  for (int thisNet = 0; thisNet < numSsid; thisNet++) {
+    Serial.print(thisNet + 1);
+    Serial.print(") ");
+    Serial.print("Signal: ");
+    Serial.print(WiFi.RSSI(thisNet));
+    Serial.print(" dBm");
+    Serial.print("\tChannel: ");
+    Serial.print(WiFi.channel(thisNet));
+    byte bssid[6];
+    Serial.print("\t\tBSSID: ");
+    printMacAddress(WiFi.BSSID(thisNet, bssid));
+    Serial.print("\tEncryption: ");
+    printEncryptionType(WiFi.encryptionType(thisNet));
+    Serial.print("\t\tSSID: ");
+    Serial.println(WiFi.SSID(thisNet));
+    Serial.flush();
+  }
+  Serial.println();
+}
+
+void printEncryptionType(int thisType) {
+  // read the encryption type and print out the name:
+  switch (thisType) {
+    case ENC_TYPE_WEP:
+      Serial.print("WEP");
+      break;
+    case ENC_TYPE_WPA:
+      Serial.print("WPA");
+      break;
+    case ENC_TYPE_WPA2:
+      Serial.print("WPA2");
+      break;
+    case ENC_TYPE_NONE:
+      Serial.print("None");
+      break;
+    case ENC_TYPE_AUTO:
+      Serial.print("Auto");
+      break;
+    case ENC_TYPE_WPA3:
+      Serial.print("WPA3");
+      break;
+    case ENC_TYPE_UNKNOWN:
+    default:
+      Serial.print("Unknown");
+      break;
+  }
+}
+
+void print2Digits(byte thisByte) {
+  if (thisByte < 0xF) {
+    Serial.print("0");
+  }
+  Serial.print(thisByte, HEX);
+}
+
+void printMacAddress(byte mac[]) {
+  for (int i = 0; i < 6; i++) {
+    if (i > 0) {
+      Serial.print(":");
+    }
+    if (mac[i] < 16) {
+      Serial.print("0");
+    }
+    Serial.print(mac[i], HEX);
+  }
+  Serial.println();
+}

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -188,6 +188,15 @@ uint8_t arduino::WiFiClass::encryptionType(uint8_t networkItem) {
   return sec2enum(ap_list[networkItem].get_security());
 }
 
+uint8_t* arduino::WiFiClass::BSSID(uint8_t networkItem, uint8_t* bssid) {
+  memcpy(bssid,  ap_list[networkItem].get_bssid(), 6);
+  return bssid;
+}
+
+uint8_t arduino::WiFiClass::channel(uint8_t networkItem) {
+  return ap_list[networkItem].get_channel();
+}
+
 int32_t arduino::WiFiClass::RSSI() {
   return wifi_if->get_rssi();
 }


### PR DESCRIPTION
implementation in cpp was missing for
```
  uint8_t* BSSID(uint8_t networkItem, uint8_t* bssid);
  uint8_t channel(uint8_t networkItem);
```
and the ScanNetworksAdvanced example is a useful tool for debugging WiFi problems.
the example is from WiFiC3 library with a little adaptation.

[overview](https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#wifi-station-networks-scan) of scan API in libraries