### PR TITLE
WiFi - make standard `config` functions work

### DIFF
--- a/libraries/SocketWrapper/src/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/src/SocketHelpers.cpp
@@ -62,8 +62,9 @@ arduino::IPAddress arduino::MbedSocketClass::dnsIP(int n) {
 }
 
 void arduino::MbedSocketClass::config(arduino::IPAddress local_ip) {
-  nsapi_addr_t convertedIP = { NSAPI_IPv4, { local_ip[0], local_ip[1], local_ip[2], local_ip[3] } };
-  _ip = SocketAddress(convertedIP);
+  IPAddress dns = local_ip;
+  dns[3] = 1;
+  config(local_ip, dns);
 }
 
 void arduino::MbedSocketClass::config(const char* local_ip) {
@@ -71,20 +72,27 @@ void arduino::MbedSocketClass::config(const char* local_ip) {
 }
 
 void arduino::MbedSocketClass::config(IPAddress local_ip, IPAddress dns_server) {
-  config(local_ip);
-  setDNS(dns_server);
+  IPAddress gw = local_ip;
+  gw[3] = 1;
+  config(local_ip, dns_server, gw);
 }
 
 void arduino::MbedSocketClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway) {
-  config(local_ip, dns_server);
-  nsapi_addr_t convertedGatewayIP = { NSAPI_IPv4, { gateway[0], gateway[1], gateway[2], gateway[3] } };
-  _gateway = SocketAddress(convertedGatewayIP);
+  IPAddress nm(255, 255, 255, 0);
+  config(local_ip, dns_server, gateway, nm);
 }
 
 void arduino::MbedSocketClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway, IPAddress subnet) {
-  config(local_ip, dns_server, gateway);
+  _useStaticIP = (local_ip != INADDR_NONE);
+  if (!_useStaticIP)
+    return;
+  nsapi_addr_t convertedIP = { NSAPI_IPv4, { local_ip[0], local_ip[1], local_ip[2], local_ip[3] } };
+  _ip = SocketAddress(convertedIP);
+  nsapi_addr_t convertedGatewayIP = { NSAPI_IPv4, { gateway[0], gateway[1], gateway[2], gateway[3] } };
+  _gateway = SocketAddress(convertedGatewayIP);
   nsapi_addr_t convertedSubnetMask = { NSAPI_IPv4, { subnet[0], subnet[1], subnet[2], subnet[3] } };
   _netmask = SocketAddress(convertedSubnetMask);
+  setDNS(dns_server);
 }
 
 void arduino::MbedSocketClass::setDNS(IPAddress dns_server1) {

--- a/libraries/SocketWrapper/src/SocketHelpers.h
+++ b/libraries/SocketWrapper/src/SocketHelpers.h
@@ -144,6 +144,7 @@ protected:
   SocketAddress _netmask = nullptr;
   SocketAddress _dnsServer1 = nullptr;
   SocketAddress _dnsServer2 = nullptr;
+  bool _useStaticIP = false;
 
   voidFuncPtr _feed_watchdog_func = nullptr;
 

--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -27,6 +27,15 @@ int arduino::WiFiClass::begin(const char* ssid, const char* passphrase) {
     return _currentNetworkStatus;
   }
 
+  wifi_if->set_dhcp(!_useStaticIP);
+  if (_useStaticIP) {
+    wifi_if->set_network(_ip, _netmask, _gateway);
+    char if_name[5];
+    wifi_if->get_interface_name(if_name);
+    wifi_if->add_dns_server(_dnsServer2, if_name);
+    wifi_if->add_dns_server(_dnsServer1, if_name); // pushes dnsServer2 at index 1
+  }
+
   nsapi_error_t result = wifi_if->connect(ssid, passphrase, ap_list[connected_ap].get_security());
 
   if(result == NSAPI_ERROR_IS_CONNECTED) {
@@ -39,8 +48,7 @@ int arduino::WiFiClass::begin(const char* ssid, const char* passphrase) {
 
 //Config Wifi to set Static IP && Disable DHCP
 void arduino::WiFiClass::config(const char* localip, const char* netmask, const char* gateway){
-  wifi_if->set_network(localip, netmask, gateway);
-  wifi_if->set_dhcp(false);
+  SocketHelpers::config(IPAddress(localip), dnsIP(0), IPAddress(gateway), IPAddress(netmask));
 }
 
 int arduino::WiFiClass::beginAP(const char* ssid, const char* passphrase, uint8_t channel) {


### PR DESCRIPTION
- make standard Arduinp `config` methods work for WiFi
- fill automatic dns, gw and netmask values
- allow reconnecting with static IP
- allow reconnecting with DHCP after static IP

PR https://github.com/arduino/ArduinoCore-mbed/pull/809 is related to return the DNS server IP

[overview](https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#wifi-station-network-interface) of WiFi API in libraries