### PR TITLE
Fix soft ap start error check

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -61,6 +61,10 @@ int arduino::WiFiClass::beginAP(const char* ssid, const char* passphrase, uint8_
   //Set ap ssid, password and channel
   softAPInterface->set_network(_ip, _netmask, _gateway);
   nsapi_error_t result = softAPInterface->start(ssid, passphrase, NSAPI_SECURITY_WPA2, channel, true /* dhcp server */, NULL, true /* cohexistance */);
+  if (result != NSAPI_ERROR_OK) {
+    _currentNetworkStatus = WL_AP_FAILED;
+    return _currentNetworkStatus;
+  }
 
   nsapi_error_t registrationResult;
   softAPInterface->unregister_event_handler();


### PR DESCRIPTION
mbed os doesn't allow to use  password with length lower than 8 character or higher then 64, when a password lower than 8 characters or higher than 64 characters is provided it returns an error, that was not managed, the consequence is that some lines later fail on `register_event_handler`  because the object is not correctly instantiated and then the Giga crush.
With this patch the error is handled returning immediately a failure status for the connections and avoiding further functions calls that access to a wrong location.

this fix https://github.com/arduino/ArduinoCore-mbed/issues/811