### PR TITLE
Notify when there is data in socket rx buffer

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -20,6 +20,10 @@ void arduino::MbedClient::readSocket() {
     int ret = NSAPI_ERROR_WOULD_BLOCK;
     do {
       if (rxBuffer.availableForStore() == 0) {
+        // Notify that the buffer is full and data needs to be processed
+        if (_data_available_cb) {
+            _data_available_cb();
+        }
         yield();
         continue;
       }
@@ -42,6 +46,10 @@ void arduino::MbedClient::readSocket() {
       mutex->unlock();
       _status = true;
     } while (ret == NSAPI_ERROR_WOULD_BLOCK || ret > 0);
+    // Notify about data in RX Buffer
+    if (_data_available_cb) {
+        _data_available_cb();
+    }
   }
 cleanup:
   _status = false;

--- a/libraries/SocketWrapper/src/MbedClient.h
+++ b/libraries/SocketWrapper/src/MbedClient.h
@@ -89,6 +89,10 @@ public:
     return sock != nullptr;
   }
 
+  void registerDataAvailableCb(mbed::Callback<void(void)> cb) {
+      _data_available_cb = cb;
+  }
+
   void setSocket(Socket* _sock);
   Socket* getSocket() { return sock; };
 
@@ -114,6 +118,7 @@ protected:
   }
 
 private:
+  mbed::Callback<void(void)> _data_available_cb;
   RingBufferN<SOCKET_BUFFER_SIZE> rxBuffer;
   bool _status = false;
   bool borrowed_socket = false;


### PR DESCRIPTION
This change makes it possible for a user of the MbedClient to get an asynchronous notification when there is data available in the RxBuffer. This eliminates the need for the receiver to either have a blocking loop or separate read thread to process incoming data. 