### PR TITLE
Support for Pico second serial port

### DIFF
--- a/variants/RASPBERRY_PI_PICO/pins_arduino.h
+++ b/variants/RASPBERRY_PI_PICO/pins_arduino.h
@@ -38,8 +38,8 @@ static const uint8_t A3  = PIN_A3;
 #define ADC_RESOLUTION 12
 
 // Serial
-#define PIN_SERIAL_TX (0ul)
-#define PIN_SERIAL_RX (1ul)
+#define PIN_SERIAL1_TX (0ul)
+#define PIN_SERIAL1_RX (1ul)
 #define PIN_SERIAL2_TX (8ul)
 #define PIN_SERIAL2_RX (9ul)
 
@@ -59,8 +59,8 @@ static const uint8_t SCK  = PIN_SPI_SCK;
 #define PIN_WIRE_SCL        (5u)
 
 #define SERIAL_HOWMANY		2
-#define SERIAL1_TX			(digitalPinToPinName(PIN_SERIAL_TX))
-#define SERIAL1_RX			(digitalPinToPinName(PIN_SERIAL_RX))
+#define SERIAL1_TX			(digitalPinToPinName(PIN_SERIAL1_TX))
+#define SERIAL1_RX			(digitalPinToPinName(PIN_SERIAL1_RX))
 #define SERIAL2_TX			(digitalPinToPinName(PIN_SERIAL2_TX))
 #define SERIAL2_RX			(digitalPinToPinName(PIN_SERIAL2_RX))
 

--- a/variants/RASPBERRY_PI_PICO/pins_arduino.h
+++ b/variants/RASPBERRY_PI_PICO/pins_arduino.h
@@ -40,6 +40,8 @@ static const uint8_t A3  = PIN_A3;
 // Serial
 #define PIN_SERIAL_TX (0ul)
 #define PIN_SERIAL_RX (1ul)
+#define PIN_SERIAL2_TX (8ul)
+#define PIN_SERIAL2_RX (9ul)
 
 // SPI
 #define PIN_SPI_MISO  (16u)
@@ -56,9 +58,11 @@ static const uint8_t SCK  = PIN_SPI_SCK;
 #define PIN_WIRE_SDA        (4u)
 #define PIN_WIRE_SCL        (5u)
 
-#define SERIAL_HOWMANY		1
+#define SERIAL_HOWMANY		2
 #define SERIAL1_TX			(digitalPinToPinName(PIN_SERIAL_TX))
 #define SERIAL1_RX			(digitalPinToPinName(PIN_SERIAL_RX))
+#define SERIAL2_TX			(digitalPinToPinName(PIN_SERIAL2_TX))
+#define SERIAL2_RX			(digitalPinToPinName(PIN_SERIAL2_RX))
 
 #define SERIAL_CDC			1
 #define HAS_UNIQUE_ISERIAL_DESCRIPTOR


### PR DESCRIPTION
Hi!

To my dismay I found Serial2 didn't work when I started messing with the Pico. 

This change adds the pin definition required for Serial 2 to GPIOs 8 & 9. I used these since the default definition for i2c is on 4&5.

I've tested this on my setup and successfully received data on Serial2.

