### PR TITLE
Libraries: Add include guard for SDRAM 

### DIFF
--- a/libraries/Portenta_SDRAM/src/SDRAM.h
+++ b/libraries/Portenta_SDRAM/src/SDRAM.h
@@ -1,3 +1,6 @@
+#ifndef __SDRAM_H
+#define __SDRAM_H
+
 #include "ea_malloc.h"
 
 #ifdef __cplusplus
@@ -36,3 +39,4 @@ private:
 extern SDRAMClass SDRAM;
 
 #endif
+#endif // __SDRAM_H

--- a/libraries/Portenta_SDRAM/src/ram_internal.h
+++ b/libraries/Portenta_SDRAM/src/ram_internal.h
@@ -1,3 +1,6 @@
+#ifndef __RAM_INTERNAL_H
+#define __RAM_INTERNAL_H
+
 bool sdram_init(void);
 
 #define MPU_REGION_SDRAM1	(MPU_REGION_NUMBER4)
@@ -56,3 +59,5 @@ bool sdram_init(void);
                                  | (size)                        << MPU_RASR_SIZE_Pos \
                                  | MPU_REGION_ENABLE             << MPU_RASR_ENABLE_Pos \
                                )
+
+#endif // __RAM_INTERNAL_H


### PR DESCRIPTION
Include `SDRAM.h` twice, I get the following error

```cpp
/home/tokiedokie/.arduino15/packages/arduino/hardware/mbed_portenta/4.0.2/libraries/Portenta_SDRAM/src/SDRAM.h:10:7: error: redefinition of 'class SDRAMClass'
 class SDRAMClass {
       ^~~~~~~~~~
In file included from /home/tokiedokie/.var/app/cc.arduino.IDE2/cache/.arduinoIDE-unsaved2024026-51-1ynz9ib.fpy2/sketch_jan26a/sketch_jan26a.ino:1:0:
/home/tokiedokie/.arduino15/packages/arduino/hardware/mbed_portenta/4.0.2/libraries/Portenta_SDRAM/src/SDRAM.h:10:7: note: previous definition of 'class SDRAMClass'
 class SDRAMClass {
       ^~~~~~~~~~
```

Adding an include guard can solve this problem.

fix: https://github.com/arduino/ArduinoCore-mbed/issues/808