### PR TITLE
SocketWrapper - use DNS of specific netif, not global

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -129,7 +129,7 @@ int arduino::MbedClient::connect(IPAddress ip, uint16_t port) {
 int arduino::MbedClient::connect(const char *host, uint16_t port) {
   SocketAddress socketAddress = SocketAddress();
   socketAddress.set_port(port);
-  getNetwork()->gethostbyname(host, &socketAddress);
+  SocketHelpers::gethostbyname(getNetwork(), host, &socketAddress);
   return connect(socketAddress);
 }
 
@@ -199,7 +199,7 @@ int arduino::MbedClient::connectSSL(const char *host, uint16_t port, bool disabl
 
   SocketAddress socketAddress = SocketAddress();
   socketAddress.set_port(port);
-  getNetwork()->gethostbyname(host, &socketAddress);
+  SocketHelpers::gethostbyname(getNetwork(), host, &socketAddress);
   return connectSSL(socketAddress);
 }
 

--- a/libraries/SocketWrapper/src/MbedUdp.cpp
+++ b/libraries/SocketWrapper/src/MbedUdp.cpp
@@ -63,7 +63,7 @@ int arduino::MbedUDP::beginPacket(IPAddress ip, uint16_t port) {
 int arduino::MbedUDP::beginPacket(const char *host, uint16_t port) {
   _host = SocketAddress(host, port);
   txBuffer.clear();
-  getNetwork()->gethostbyname(host, &_host);
+  SocketHelpers::gethostbyname(getNetwork(), host, &_host);
   //If IP is null and port is 0 the initialization failed
   return (_host.get_ip_address() == nullptr && _host.get_port() == 0) ? 0 : 1;
 }

--- a/libraries/SocketWrapper/src/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/src/SocketHelpers.cpp
@@ -17,7 +17,7 @@ String arduino::MbedSocketClass::macAddress() {
 
 int arduino::MbedSocketClass::hostByName(const char* aHostname, IPAddress& aResult) {
   SocketAddress socketAddress = SocketAddress();
-  nsapi_error_t returnCode = getNetwork()->gethostbyname(aHostname, &socketAddress);
+  nsapi_error_t returnCode = gethostbyname(getNetwork(), aHostname, &socketAddress);
   nsapi_addr_t address = socketAddress.get_addr();
   aResult[0] = address.bytes[0];
   aResult[1] = address.bytes[1];
@@ -120,6 +120,11 @@ SocketAddress arduino::MbedSocketClass::socketAddressFromIpAddress(arduino::IPAd
   return SocketAddress(convertedIP, port);
 }
 
+nsapi_error_t arduino::MbedSocketClass::gethostbyname(NetworkInterface* interface, const char* aHostname, SocketAddress* socketAddress) {
+  char ifname[5] {};
+  interface->get_interface_name(ifname);
+  return interface->gethostbyname(aHostname, socketAddress, NSAPI_UNSPEC, ifname);
+}
 
 // Download helper
 

--- a/libraries/SocketWrapper/src/SocketHelpers.h
+++ b/libraries/SocketWrapper/src/SocketHelpers.h
@@ -154,6 +154,7 @@ protected:
 
   static arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
   static SocketAddress socketAddressFromIpAddress(arduino::IPAddress ip, uint16_t port);
+  static nsapi_error_t gethostbyname(NetworkInterface* interface, const char* aHostname, SocketAddress* socketAddress);
 };
 
 using SocketHelpers = MbedSocketClass;


### PR DESCRIPTION
DNS IP address assigned by DHCP was not used.
Instead DNS servers hardcoded in Mbed were used.

error report https://forum.arduino.cc/t/ethernet-dhcp-issue/1231893