### PR TITLE
Correct servertype identifier in "BlackMagic" programmer definition

### DIFF
--- a/programmers.txt
+++ b/programmers.txt
@@ -35,4 +35,4 @@ blackmagic.program.protocol=
 blackmagic.program.tool=
 blackmagic.program.tool.default=
 blackmagic.program.extra_params=
-blackmagic.debug.server=blackmagic
+blackmagic.debug.server=bmp


### PR DESCRIPTION
When Arduino IDE initializes the [integrated sketch debugger](https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-debugger), it sets the [`servertype` debug attribute](https://github.com/Marus/cortex-debug/blob/cfff611cc3578386c7ea83eebe6627bc2c013cef/debug_attributes.md#:~:text=in%20your%20PATH-,servertype,-string) to the value of the `debug.server` platform property.

This property must be set to one of the GDB Server type identifiers recognized by the Cortex-Debug debugger extension:

https://github.com/Marus/cortex-debug/blob/cfff611cc3578386c7ea83eebe6627bc2c013cef/debug_attributes.md#:~:text=in%20your%20PATH-,servertype,-string

> supported types are jlink, openocd, pyocd, pe, stlink, stutil, qemu, bmp and external.

The previous value was not a recognized identifier, which caused the debugger initialization to fail:

```text
Invalid servertype parameters. The following values are supported: "jlink", "openocd", "stlink", "stutil", "pyocd", "bmp", "pe", "qemu", "external"
```