### PR TITLE
Added Portenta C33 (0068) to post_install.sh

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -9,6 +9,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2e8a", MODE:="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", MODE:="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", MODE:="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0525", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0068", MODE:="0666"            #   Portenta C33
 EOF
 }
 


### PR DESCRIPTION
I added the Portenta C33 (0068) to postinstall.sh so the udev rules would include it. This fixes the upload error 74 in Linux.