### PR TITLE
NICLA VISION TLS skip server certificate date check

### DIFF
--- a/variants/NICLA_VISION/conf/custom_mbedtls_config.h
+++ b/variants/NICLA_VISION/conf/custom_mbedtls_config.h
@@ -186,7 +186,7 @@ void * tstDoTraceAndCalloc(
  * mbedtls_platform_gmtime_r() at compile-time by using the macro
  * MBEDTLS_PLATFORM_GMTIME_R_ALT.
  */
-#define MBEDTLS_HAVE_TIME_DATE
+//#define MBEDTLS_HAVE_TIME_DATE
 
 /**
  * \def MBEDTLS_PLATFORM_MEMORY

--- a/variants/NICLA_VISION/conf/custom_mbedtls_config.h
+++ b/variants/NICLA_VISION/conf/custom_mbedtls_config.h
@@ -1163,7 +1163,7 @@ void * tstDoTraceAndCalloc(
  *
  * Enable functions that use the filesystem.
  */
-#define MBEDTLS_FS_IO
+//#define MBEDTLS_FS_IO
 
 /**
  * \def MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
@@ -2770,7 +2770,7 @@ void * tstDoTraceAndCalloc(
  *            on it, and considering stronger message digests instead.
  *
  */
-#define MBEDTLS_SHA1_C
+//#define MBEDTLS_SHA1_C
 
 /**
  * \def MBEDTLS_SHA256_C


### PR DESCRIPTION
This check was enabled only for NICLA VISION, and connect was failing because system time is not automatically configured. On other variants date checks are not enabled because `MBEDTLS_HAVE_TIME_DATE` is not defined.