### PR TITLE
Ethernet begin with static IP - set DNS with interface name

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -55,7 +55,9 @@ int arduino::EthernetClass::begin(uint8_t *mac, IPAddress ip, IPAddress dns, IPA
 
   eth_if->set_dhcp(false);
   eth_if->set_network(_ip, _netmask, _gateway);
-  eth_if->add_dns_server(_dnsServer1, nullptr);
+  char if_name[5];
+  eth_if->get_interface_name(if_name);
+  eth_if->add_dns_server(_dnsServer1, if_name);
 
   auto ret = _begin(mac, timeout, responseTimeout);
   return ret;


### PR DESCRIPTION
this is another PR from the series of setting/reading/using the DNS server IP associated with the specific network interface because the DHCP code in Mbed sets the DNS IP that way and the Arduino API DNS related functions don't allow us to get/manage DNS server IPs from two different registers (global and netif specific).