### PR TITLE
WiFi.h - methods without implementation removed

### DIFF
--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -187,13 +187,6 @@ public:
 
   unsigned long getTime();
 
-  void lowPowerMode();
-  void noLowPowerMode();
-
-  int ping(const char* hostname, uint8_t ttl = 128);
-  int ping(const String& hostname, uint8_t ttl = 128);
-  int ping(IPAddress host, uint8_t ttl = 128);
-
   friend class WiFiClient;
   friend class WiFiServer;
   friend class WiFiUDP;


### PR DESCRIPTION
`ping` and power mode functions do not have an implementation. to avoid confusion better remove them.

https://forum.arduino.cc/t/issues-compiling-with-wifi-ping/1244065