### PR TITLE
RPC Library: Add a function to return the current CPU ID.

### DIFF
--- a/libraries/RPC/examples/Basic_AddSub/Basic_AddSub.ino
+++ b/libraries/RPC/examples/Basic_AddSub/Basic_AddSub.ino
@@ -17,7 +17,7 @@ void setup() {
   RPC.begin();
   RPC.bind("add", add);
   RPC.bind("sub", sub);
-  if (HAL_GetCurrentCPUID() == CM7_CPUID) {
+  if (RPC.cpu_id() == CM7_CPUID) {
     // Introduce a brief delay to allow the M4 sufficient time
     // to bind remote functions before invoking them.
     delay(100);
@@ -29,7 +29,7 @@ void loop() {
   static size_t loop_count = 0;
 
   // Blink every 512 iterations
-  if (HAL_GetCurrentCPUID() == CM4_CPUID && (loop_count++ % 512) == 0) {
+  if (RPC.cpu_id() == CM4_CPUID && (loop_count++ % 512) == 0) {
     digitalWrite(LEDG, LOW);
     delay(10);
     digitalWrite(LEDG, HIGH);
@@ -37,12 +37,12 @@ void loop() {
   }
 
   int res = RPC.call("add", 1, 2).as<int>();
-  if (HAL_GetCurrentCPUID() == CM7_CPUID) {
+  if (RPC.cpu_id() == CM7_CPUID) {
     Serial.println("add(1, 2) = " + String(res));
   }
 
   res = RPC.call("sub", res, 1).as<int>();
-  if (HAL_GetCurrentCPUID() == CM7_CPUID) {
+  if (RPC.cpu_id() == CM7_CPUID) {
     Serial.println("sub(3, 1) = " + String(res));
   }
   delay(250);

--- a/libraries/RPC/examples/RPC_m4/RPC_m4.ino
+++ b/libraries/RPC/examples/RPC_m4/RPC_m4.ino
@@ -11,7 +11,7 @@ Thread subtractThread;
    Note that the sketch has to be uploaded to both cores.
  **/
 String currentCPU() {
-  if (HAL_GetCurrentCPUID() == CM7_CPUID) {
+  if (RPC.cpu_id() == CM7_CPUID) {
     return "M7";
   } else {
     return "M4";

--- a/libraries/RPC/examples/SerialPassthrough_RPC/SerialPassthrough_RPC.ino
+++ b/libraries/RPC/examples/SerialPassthrough_RPC/SerialPassthrough_RPC.ino
@@ -9,7 +9,7 @@ void setup() {
 }
 
 void loop() {
-  if (HAL_GetCurrentCPUID() == CM4_CPUID) {
+  if (RPC.cpu_id() == CM4_CPUID) {
     RPC.println("Printed from M4 core");
     delay(1000);
   } else {

--- a/libraries/RPC/src/RPC.h
+++ b/libraries/RPC/src/RPC.h
@@ -42,19 +42,26 @@ class RPCClass : public Stream, public rpc::detail::dispatcher {
             for (int i = 0; i< 10; i++) {
                 clients[i] = NULL;
             }
-        };
+        }
         int begin();
-        void end() {};
+        void end() {
+
+        }
         int available(void) {
             return rx_buffer.available();
-        };
+        }
         int peek(void) {
             return rx_buffer.peek();
         }
         int read(void) {
             return rx_buffer.read_char();
         }
-        void flush(void) {};
+        void flush(void) {
+
+        }
+        uint32_t cpu_id() {
+            return HAL_GetCurrentCPUID();
+        }
         size_t write(uint8_t c);
         size_t write(const uint8_t *buf, size_t len, bool raw = true);
 


### PR DESCRIPTION
Ideally, HAL functions should not be called directly from sketches.