### PR TITLE
Mbedclient stop issue

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -299,6 +299,7 @@ void arduino::MbedClient::stop() {
     mutex = nullptr;
   }
   _status = false;
+  rxBuffer.clear();
 }
 
 uint8_t arduino::MbedClient::connected() {

--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -65,7 +65,7 @@ void arduino::MbedClient::configureSocket(Socket *_s) {
   _s->set_timeout(_timeout);
   _s->set_blocking(false);
   _s->getpeername(&address);
-  
+
   if (event == nullptr) {
     event = new rtos::EventFlags;
   }


### PR DESCRIPTION
The `MbedClient` class has some issues in the `stop()` method that affect the ability to reuse the client after calling the `stop()` function