### PR TITLE
MbedClient: improving logic of readSocket

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -22,15 +22,13 @@ void arduino::MbedClient::readSocket() {
     int ret = NSAPI_ERROR_WOULD_BLOCK;
     do {
       mutex->lock();
-      if (sock == nullptr) {
-        goto cleanup;
-      }
-      mutex->unlock();
-      if (rxBuffer.availableForStore() == 0) {
+      if (sock != nullptr && rxBuffer.availableForStore() == 0) {
+        mutex->unlock();
         yield();
         continue;
+      } else if (sock == nullptr) {
+        goto cleanup;
       }
-      mutex->lock();
       ret = sock->recv(data, rxBuffer.availableForStore());
       if (ret < 0 && ret != NSAPI_ERROR_WOULD_BLOCK) {
         goto cleanup;


### PR DESCRIPTION
This PR aims to address the issue introduced in https://github.com/arduino/ArduinoCore-mbed/pull/868.
In which case when `yield()` is called by the `readSocket` thread, it could happen that the socket is deleted by the main thread and then accessed by the `readSocket` thread again, while being null. This PR is currently under test and it will be merged if this issue is not observed anymore.