### PR TITLE
libraries/Arduino_H7_Video: Fix the DSI PLL configuration.

### DIFF
--- a/libraries/Arduino_H7_Video/src/dsi.cpp
+++ b/libraries/Arduino_H7_Video/src/dsi.cpp
@@ -48,7 +48,7 @@ static void dsi_layerInit(uint16_t LayerIndex, uint32_t FB_Address);
 int dsi_init(uint8_t bus, struct edid *edid, struct display_timing *dt) {
 #ifdef ARDUINO_GIGA
 	static const uint32_t DSI_PLLNDIV = 125;
-	static const uint32_t DSI_PLLIDF = DSI_PLL_IN_DIV3;
+	static const uint32_t DSI_PLLIDF = DSI_PLL_IN_DIV4;
 	static const uint32_t DSI_PLLODF = DSI_PLL_OUT_DIV1;
 	static const uint32_t DSI_TXEXCAPECLOCKDIV = 4;
 	#undef HSE_VALUE


### PR DESCRIPTION
With the current configuration (NDIV=125, PLLIDF=3, PLLODF=1) the DSI PLL outputs an out of spec 83MHz clock. This fix sets the output clock to the max supported clock of 62.5MHz, according to the datasheet.

Also happens to fix issue #743

Current settings:
![image](https://github.com/arduino/ArduinoCore-mbed/assets/4498013/bcda4f9b-4c7f-4069-b08f-83d7a29fec15)
