### PR TITLE
WiFi - setHostname declaration removed

### DIFF
--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -85,13 +85,6 @@ public:
 
   int beginAP(const char* ssid, const char* passphrase, uint8_t channel = DEFAULT_AP_CHANNEL);
 
-  /* Set the hostname used for DHCP requests
-     *
-     * param name: hostname to set
-     *
-     */
-  void setHostname(const char* name);
-
   /*
      * Disconnect from the network
      *


### PR DESCRIPTION
WiFi::setHostname declaration removed, because there is no implementation. Mbed doesn't support it.

btw I thought I removed it long time ago.

related issue https://github.com/arduino/ArduinoCore-mbed/issues/881