### PR TITLE
Display useful message when Linux post-install script has insufficient permissions

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -12,8 +12,19 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0525", MODE:="0666"
 EOF
 }
 
-if [ "$EUID" -ne 0 ]
-  then echo "Please run as root"
+if [ "$EUID" -ne 0 ]; then
+  if [ -e "${PWD}/post_install.sh" ]; then
+    echo
+    echo "You might need to configure permissions for uploading."
+    echo "To do so, run the following command from the terminal:"
+    echo "sudo \"${PWD}/post_install.sh\""
+    echo
+  else
+    # Script was executed from another path. It is assumed this will only occur when user is executing script directly.
+    # So it is not necessary to provide the command line.
+    echo "Please run as root"
+  fi
+
   exit
 fi
 


### PR DESCRIPTION
The Arduino Boards Manager automatically executes the `post_install.sh` script during installation of the platform on a Linux machine:

https://arduino.github.io/arduino-cli/dev/platform-specification/#post-install-script

This platform's post-install script is intended to create a [**udev** rules file](https://man7.org/linux/man-pages/man7/udev.7.html#RULES_FILES) that gives write permissions for the USB devices of the platform's boards. These permissions are required in order to upload to the boards.

The creation of the udev rules file requires superuser privileges, which are typically not available in the context of the post-install script's execution by the Arduino development software. The script contains code to [check whether the necessary privileges are available](https://github.com/arduino/ArduinoCore-mbed/blob/6293cea686adbd606fa40ba2966f97f411bdd3ac/post_install.sh#L15). If not, it prints a message and [skips the udev rules file creation](https://github.com/arduino/ArduinoCore-mbed/blob/6293cea686adbd606fa40ba2966f97f411bdd3ac/post_install.sh#L17).

Previously the message printed when the udev rules file creation was not possible was "Please run as root":

```text
Downloading packages
arduino:mbed_nano@4.1.3
Installing platform arduino:mbed_nano@4.1.3
Configuring platform.
Please run as root

Platform arduino:mbed_nano@4.1.3 installed
```

That "Please run as root" message was completely meaningless to the user when printed during the Boards Manager installation. Worse, it might cause them
to think they must run the Arduino development software as root user, which is a bad idea and also wouldn't result in
the udev rules file being created since the installation of the platform to the user's account was already completed.

The script is here updated to provide a meaningful explanation of the potential problem as well as the specific command the user can run from the terminal to execute the script as superuser:

```text
Downloading packages
arduino:mbed_nano@4.1.3
Installing platform arduino:mbed_nano@4.1.3
Configuring platform.

You might need to configure write permissions for uploading.
Run the following command from the terminal:
sudo "/home/per/.arduino15/packages/arduino/hardware/mbed_nano/4.1.3/post_install.sh"


Platform arduino:mbed_nano@4.1.3 installed
```

---

This is a propagation of a change originally implemented in the `arduino/ArduinoCore-renesas` repo: https://github.com/arduino/ArduinoCore-renesas/pull/334