### PR TITLE
SocketWrapper MbedClient read() fixes

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -229,6 +229,8 @@ int arduino::MbedClient::available() {
 }
 
 int arduino::MbedClient::read() {
+  if (sock == nullptr)
+    return -1;
   mutex->lock();
   if (!available()) {
     mutex->unlock();
@@ -241,6 +243,8 @@ int arduino::MbedClient::read() {
 }
 
 int arduino::MbedClient::read(uint8_t *data, size_t len) {
+  if (sock == nullptr)
+    return 0;
   mutex->lock();
   int avail = available();
 


### PR DESCRIPTION
this PR for SocketWrapper's MbedClient fixes crash when invoking read() on stopped client

btw. I am very surprised that read(buff, size) should return -1 if no data are available and 0 if the connection is closed. this is how it is in the documentation and in Ethernet library implementation. and apparently this is how it is in BSD sockets. it is very strange for me.
WiFi101 and Portenta Core's lwipClient return -1 too if no bytes are available
WiFiNINA, WiFiS3, esp8266, esp32 return 0 from read(buff, size) if no data are available

a complete research: https://github.com/Networking-for-Arduino/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#clientreadbuff-size-return-value