### PR TITLE
properly initialized and checked Ethernet init callback (fix #890)

### DIFF
--- a/libraries/Ethernet/src/Ethernet.cpp
+++ b/libraries/Ethernet/src/Ethernet.cpp
@@ -5,7 +5,10 @@
 int arduino::EthernetClass::begin(uint8_t *mac, unsigned long timeout, unsigned long responseTimeout) {
   if (eth_if == nullptr) {
     //Q: What is the callback for?
-    _initializerCallback();
+    //A: To call a specific function on your system before any initialization is performed
+    if(_initializerCallback != nullptr) {
+      _initializerCallback();
+    }
     if (eth_if == nullptr) return 0;
   }
   eth_if->set_dhcp(true);

--- a/libraries/Ethernet/src/Ethernet.h
+++ b/libraries/Ethernet/src/Ethernet.h
@@ -121,7 +121,7 @@ private:
   volatile EthernetLinkStatus _currentNetworkStatus = Unknown;
   EthernetInterface net;
   EthernetInterface *eth_if = &net;
-  voidPrtFuncPtr _initializerCallback;
+  voidPrtFuncPtr _initializerCallback = nullptr;
   arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
 };
 


### PR DESCRIPTION
fix for potential null pointer access / _initializerCallback not initialized #890 
This PR properly initializes _initializerCallback function pointer and checks for its validity before to call it