### PR TITLE
MbedClient add network status check

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -10,7 +10,7 @@ arduino::MbedClient::MbedClient()
 }
 
 uint8_t arduino::MbedClient::status() {
-  return _status;
+  return (_status && (getNetwork()->get_connection_status() < NSAPI_STATUS_DISCONNECTED));
 }
 
 

--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -305,7 +305,7 @@ void arduino::MbedClient::stop() {
 }
 
 uint8_t arduino::MbedClient::connected() {
-  return ((_status) || (available() > 0));
+  return ((status() == true) || (available() > 0));
 }
 
 IPAddress arduino::MbedClient::remoteIP() {


### PR DESCRIPTION
This PR makes `connected()`  consider also network status. In some conditions: WiFi turning ON and OFF or Ethernet cable connections and disconnections `connected()` returns 1 even if network is in reality disconnected.

~~Also `status()` is a bit confusing so i make it private, users can still check Client status using `connected()`~~