### PR TITLE
SocketWrapper MbedClient debugging readSocket

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -22,28 +22,30 @@ void arduino::MbedClient::readSocket() {
     int ret = NSAPI_ERROR_WOULD_BLOCK;
     do {
       mutex->lock();
-      if (sock != nullptr && rxBuffer.availableForStore() == 0) {
+      if (sock == nullptr) {
+        mutex->unlock();
+        goto cleanup;
+      }
+      if (rxBuffer.availableForStore() == 0) {
         mutex->unlock();
         yield();
         continue;
-      } else if (sock == nullptr) {
-        goto cleanup;
       }
       ret = sock->recv(data, rxBuffer.availableForStore());
       if (ret < 0 && ret != NSAPI_ERROR_WOULD_BLOCK) {
+        mutex->unlock();
         goto cleanup;
       }
       if (ret == NSAPI_ERROR_WOULD_BLOCK || ret == 0) {
-        yield();
         mutex->unlock();
-        continue;
+        break;
       }
       for (int i = 0; i < ret; i++) {
         rxBuffer.store_char(data[i]);
       }
       mutex->unlock();
       _status = true;
-    } while (ret == NSAPI_ERROR_WOULD_BLOCK || ret > 0);
+    } while (true);
   }
 cleanup:
   _status = false;
@@ -98,6 +100,7 @@ int arduino::MbedClient::connect(SocketAddress socketAddress) {
   }
 
   if (static_cast<TCPSocket *>(sock)->open(getNetwork()) != NSAPI_ERROR_OK) {
+    _status = false;
     return 0;
   }
 
@@ -117,6 +120,7 @@ int arduino::MbedClient::connect(SocketAddress socketAddress) {
     configureSocket(sock);
     _status = true;
   } else {
+    sock->close();
     _status = false;
   }
 
@@ -148,6 +152,7 @@ int arduino::MbedClient::connectSSL(SocketAddress socketAddress) {
   }
 
   if (static_cast<TLSSocket *>(sock)->open(getNetwork()) != NSAPI_ERROR_OK) {
+    _status = false;
     return 0;
   }
 
@@ -179,6 +184,7 @@ restart_connect:
     configureSocket(sock);
     _status = true;
   } else {
+    sock->close();
     _status = false;
   }
 
@@ -224,8 +230,9 @@ int arduino::MbedClient::available() {
 }
 
 int arduino::MbedClient::read() {
-  if (sock == nullptr)
+  if (mutex == nullptr) {
     return -1;
+  }
   mutex->lock();
   if (!available()) {
     mutex->unlock();
@@ -238,8 +245,9 @@ int arduino::MbedClient::read() {
 }
 
 int arduino::MbedClient::read(uint8_t *data, size_t len) {
-  if (sock == nullptr)
+  if (mutex == nullptr) {
     return 0;
+  }
   mutex->lock();
   int avail = available();
 
@@ -261,7 +269,14 @@ int arduino::MbedClient::read(uint8_t *data, size_t len) {
 }
 
 int arduino::MbedClient::peek() {
-  return rxBuffer.peek();
+  if (mutex == nullptr) {
+    return 0;
+  }
+  mutex->lock();
+  int res = rxBuffer.peek();
+  mutex->unlock();
+
+  return res;
 }
 
 void arduino::MbedClient::flush() {


### PR DESCRIPTION
1) In `connect` we have to delete the socket object, because all other functions test it for null and then use mutex which is null, because configureSocket was not invoked. And there are too few sockets in total.

2) In `readSocket` the condition of the inner loop was always true and the inner loop never exited to wait for event or timeout on event. The inner loop only paused for yield(). With the PR if no data are available the inner loop does `break` to outer loop where the thread waits for event or timeout. 

<del>3) I think we have to do mutex in `write` too</del>