### PR TITLE
SPI mutex lock

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -81,9 +81,11 @@ void arduino::MbedSPI::beginTransaction(SPISettings settings) {
         dev->obj->frequency(settings.getClockFreq());
         this->settings = settings;
     }
+    spiLockMutex.lock();
 }
 
 void arduino::MbedSPI::endTransaction(void) {
+    spiLockMutex.unlock();
     // spinlock until transmission is over (if using ASYNC transfer)
 }
 

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -20,6 +20,7 @@
 
 #include "Arduino.h"
 #include "api/HardwareSPI.h"
+#include <Mutex.h>
 
 typedef struct _mbed_spi mbed_spi;
 
@@ -50,6 +51,7 @@ public:
 private:
     SPISettings settings = SPISettings(0, MSBFIRST, SPI_MODE0);
     _mbed_spi* dev = NULL;
+    rtos::Mutex spiLockMutex;
     PinName _miso;
     PinName _mosi;
     PinName _sck;


### PR DESCRIPTION
I am not sure if this is the correct and complete solution, but it solved the problem with W5500 and SD card on SPI pins of the Nano RP2040. The W5500 was handled by my W5500-EMAC library with the PortentaEthernet and SocketWrapper library with the readSocket thread.