### PR TITLE
mbed-os-to-arduino "mbed new" doesn't create the mbed-os folder

### DIFF
--- a/mbed-os-to-arduino
+++ b/mbed-os-to-arduino
@@ -53,6 +53,8 @@ mbed_revision () {
 				rm -rf mbed-os
 				ln -s "$LOCAL_REPO" mbed-os
 			fi
+        else
+			ln -s "$LOCAL_REPO" mbed-os
 		fi
 	fi
 	echo " done."


### PR DESCRIPTION
`mbed new` doesn't clone mbed-os into /tmp/mbed-os-program (maybe because it is a non standard location).
then the rest of the script doesn't work. 
this PR fixes it for link to local repo, so if used with -r.

additionally the script requires
```
export PATH=$PATH:~/.arduino15/packages/arduino/tools/arm-none-eabi-gcc/7-2017q4/bin
```
to finish successful, but I guess it is not right to put it into the script