### PR TITLE
SocketWrapper lib Client setConnectionTimeout added

### DIFF
--- a/libraries/SocketWrapper/src/AClient.cpp
+++ b/libraries/SocketWrapper/src/AClient.cpp
@@ -18,6 +18,11 @@ void arduino::AClient::setSocket(Socket *sock) {
   client->setSocket(sock);
 }
 
+void arduino::AClient::setConnectionTimeout(unsigned long timeout) {
+  setSocketTimeout(timeout);
+}
+
+
 void arduino::AClient::setSocketTimeout(unsigned long timeout) {
   if (!client) {
     newMbedClient();

--- a/libraries/SocketWrapper/src/AClient.h
+++ b/libraries/SocketWrapper/src/AClient.h
@@ -53,6 +53,7 @@ public:
 
   using Print::write;
 
+  void setConnectionTimeout(unsigned long timeout);
   void setSocketTimeout(unsigned long timeout);
 
 protected:

--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -100,7 +100,7 @@ int arduino::MbedClient::connect(SocketAddress socketAddress) {
   if (static_cast<TCPSocket *>(sock)->open(getNetwork()) != NSAPI_ERROR_OK) {
     return 0;
   }
-
+  sock->set_timeout(_timeout);
   nsapi_error_t returnCode = static_cast<TCPSocket *>(sock)->connect(socketAddress);
   int ret = 0;
 


### PR DESCRIPTION
In https://github.com/arduino/ArduinoCore-mbed/pull/769 I wrote in a comment

> it is not a connection timeout as setConnectionTimeout should do! it is timeout on other operations, not on connect.

reading the Mbed TCPSocket.cpp source, I see that this is not true and Mbed uses that timeout in `connect`. Sorry. My mistake was my assumption that it works the same way as in LwIP, but Mbed adds some logic as it wraps LwIP.

this PR adds setConnectionTimeout as alias to setSocketTimeout and sets the timeout before `connect`

this timeout is now applied in MbedClient in `connect`, `stop` and `write`. `read` shouldn't block in Arduino API so in `read` the timeout is not used.