### PR TITLE
Configure post-install script to only operate when platform installed on Linux machine

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -12,25 +12,31 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0525", MODE:="0666"
 EOF
 }
 
-if [ "$EUID" -ne 0 ]; then
-  if [ -e "${PWD}/post_install.sh" ]; then
-    echo
-    echo "You might need to configure permissions for uploading."
-    echo "To do so, run the following command from the terminal:"
-    echo "sudo \"${PWD}/post_install.sh\""
-    echo
-  else
-    # Script was executed from another path. It is assumed this will only occur when user is executing script directly.
-    # So it is not necessary to provide the command line.
-    echo "Please run as root"
+OS="$(uname -s)"
+case "$OS" in
+Linux*)
+  if [ "$EUID" -ne 0 ]; then
+    if [ -e "${PWD}/post_install.sh" ]; then
+      echo
+      echo "You might need to configure permissions for uploading."
+      echo "To do so, run the following command from the terminal:"
+      echo "sudo \"${PWD}/post_install.sh\""
+      echo
+    else
+      # Script was executed from another path. It is assumed this will only occur when user is executing script directly.
+      # So it is not necessary to provide the command line.
+      echo "Please run as root"
+    fi
+
+    exit
   fi
 
-  exit
-fi
+  arduino_mbed_rules > /etc/udev/rules.d/60-arduino-mbed.rules
 
-arduino_mbed_rules > /etc/udev/rules.d/60-arduino-mbed.rules
+  # reload udev rules
+  echo "Reload rules..."
+  udevadm trigger
+  udevadm control --reload-rules
 
-# reload udev rules
-echo "Reload rules..."
-udevadm trigger
-udevadm control --reload-rules
+  ;;
+esac


### PR DESCRIPTION
The Arduino Boards Manager automatically executes the `post_install.sh` script during installation of the platform on a non-Windows machine:

https://arduino.github.io/arduino-cli/dev/platform-specification/#post-install-script

The platform's post-install script is Linux-specific, but no provisions were made in the script code for the fact that it is also executed on macOS machines. Previously, this was fairly innocuous because, although misleading, the message printed to the output during the platform installation was short and cryptic and thus easy for the average macOS user to ignore:

```text
Configuring platform.
Please run as root
```

Since it is important for Linux users to manually run the script and the previous message did not effectively communicate that, the script was recently modified to print helpful instructions during the Boards Manager installation (https://github.com/arduino/ArduinoCore-mbed/pull/893). The fact that the script is also executed on macOS machines was not considered in that work. This meant that, although an improvement for the Linux user experience was accomplished, the macOS user experience was worsened because those users were then presented with more prominent and detailed inappropriate instructions than the former easy to miss "Please run as root" instruction. For example

```text
Configuring platform.

You might need to configure permissions for uploading.
To do so, run the following command from the terminal:
sudo "/Users/per/Library/Arduino15/packages/arduino/hardware/mbed_giga/4.1.5/post_install.sh"
```

The problem is fixed by adjusting the script so that the script simply returns silently if it is invoked on a non-Linux machine. macOS users will now only see the following benign message in the output during the Boards Manager installation:

```text
Configuring platform.
```

### Additional context

The POSIX-compliant shell code for determining the operating system the script is running under was derived from the Arduino CLI application's cross-platform installation script:

https://github.com/arduino/arduino-cli/blob/v1.0.3/install.sh#L61-L70

That code has withstood the test of time after years of use by a large user base.

---

Originally reported at https://forum.arduino.cc/t/ide-2-3-2-message-installing-opta-board/1284278

I also remember seeing a prior comment about the issue, I believe in this repository, but I could not manage to find it.