### PR TITLE
programmers: allow overriding default programmer

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -443,6 +443,8 @@ nicla_sense.upload.wait_for_upload_port=true
 nicla_sense.upload.native_usb=true
 nicla_sense.upload.maximum_size=527616
 nicla_sense.upload.maximum_data_size=64288
+nicla_sense.programmer.protocol=cmsis-dap
+nicla_sense.programmer.transport_script={runtime.platform.path}/debugger/select_swd.cfg
 
 nicla_sense.bootloader.tool=openocd
 nicla_sense.bootloader.tool.default=openocd
@@ -496,6 +498,8 @@ nicla_voice.upload.wait_for_upload_port=true
 nicla_voice.upload.native_usb=true
 nicla_voice.upload.maximum_size=527616
 nicla_voice.upload.maximum_data_size=64288
+nicla_voice.programmer.protocol=cmsis-dap
+nicla_voice.programmer.transport_script={runtime.platform.path}/debugger/select_swd.cfg
 
 nicla_voice.bootloader.tool=openocd
 nicla_voice.bootloader.tool.default=openocd

--- a/platform.txt
+++ b/platform.txt
@@ -125,11 +125,11 @@ tools.openocd.cmd.windows=bin/openocd.exe
 
 tools.openocd.upload.params.verbose=-d2
 tools.openocd.upload.params.quiet=-d0
-tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -s "{path}/share/openocd/scripts/" {bootloader.programmer} {upload.transport} {bootloader.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; program {{build.path}/{build.project_name}.elf}; reset run; shutdown"
+tools.openocd.upload.pattern="{path}/{cmd}" {upload.verbose} -s "{path}/share/openocd/scripts/" -f interface/{programmer.protocol}.cfg -f {programmer.transport_script} {bootloader.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; program {{build.path}/{build.project_name}.elf}; reset run; shutdown"
 
 tools.openocd.program.params.verbose=-d2
 tools.openocd.program.params.quiet=-d0
-tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} -s "{path}/share/openocd/scripts/" {bootloader.programmer} {upload.transport} {bootloader.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; program {{build.path}/{build.project_name}.elf}; reset run; shutdown"
+tools.openocd.program.pattern="{path}/{cmd}" {program.verbose} -s "{path}/share/openocd/scripts/" -f interface/{programmer.protocol}.cfg -f {programmer.transport_script} {bootloader.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; program {{build.path}/{build.project_name}.elf}; reset run; shutdown"
 
 tools.openocd.erase.params.verbose=-d2
 tools.openocd.erase.params.quiet=-d0
@@ -137,7 +137,7 @@ tools.openocd.erase.pattern=
 
 tools.openocd.bootloader.params.verbose=-d2
 tools.openocd.bootloader.params.quiet=-d0
-tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/share/openocd/scripts/" {bootloader.programmer} {upload.transport} {bootloader.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; {bootloader.extra_action.preflash}; program {{runtime.platform.path}/bootloaders/{bootloader.file}}; reset run; shutdown"
+tools.openocd.bootloader.pattern="{path}/{cmd}" {bootloader.verbose} -s "{path}/share/openocd/scripts/" -f interface/{programmer.protocol}.cfg -f {programmer.transport_script} {bootloader.config} -c "telnet_port disabled; init; reset init; halt; adapter speed 10000; {bootloader.extra_action.preflash}; program {{runtime.platform.path}/bootloaders/{bootloader.file}}; reset run; shutdown"
 
 #
 # BOSSA


### PR DESCRIPTION
Should fix   ~#939~ and #940

It looks like openocd on RP2040 had a regression (apart from the name change `rp2040-core0 `-> `rp2040`  )
Investigation is ongoing, tracked in #704