### PR TITLE
PDM: fix setGain() for dfsdm

### DIFF
--- a/libraries/PDM/src/STM32H747_dfsdm/audio.c
+++ b/libraries/PDM/src/STM32H747_dfsdm/audio.c
@@ -391,7 +391,10 @@ int py_audio_init(size_t channels, uint32_t frequency)
 
 void py_audio_gain_set(int gain_db)
 {
-  attenuation = 8 - gain_db;
+  attenuation = 8 - (gain_db / 3);
+  if (attenuation < 0) {
+    attenuation = 0;
+  }
 }
 
 void py_audio_deinit()


### PR DESCRIPTION
If the gain was too high, the right bit shift
  `RecBuff[i] >> attenuation`
would result in undefined behaviour
https://www.iso-9899.info/n1570.html#6.5.7

Take the chance to also fix the (approximate) conversion from gain (in dB) to bit shift

