### PR TITLE
enforcing stop() when calling connect a second time

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -80,14 +80,8 @@ void arduino::MbedClient::configureSocket(Socket *_s) {
 }
 
 int arduino::MbedClient::connect(SocketAddress socketAddress) {
-
-  if (sock && reader_th) {
-    // trying to reuse a connection, let's call stop() to cleanup the state
-    char c;
-    if (sock->recv(&c, 1) < 0) {
-      stop();
-    }
-  }
+  // if a connection is aready ongoing, a disconnection must be enforced before starting another one
+  stop();
 
   if (sock == nullptr) {
     sock = new TCPSocket();
@@ -135,6 +129,9 @@ int arduino::MbedClient::connect(const char *host, uint16_t port) {
 }
 
 int arduino::MbedClient::connectSSL(SocketAddress socketAddress) {
+  // if a connection is aready ongoing, a disconnection must be enforced before starting another one
+  stop();
+
   if (sock == nullptr) {
     sock = new TLSSocket();
     _own_socket = true;


### PR DESCRIPTION
This PR aims to fix the issue for which the client is not able to connect again after the connection is lost. In this way we stop the connection every time we desire to connect to something.