### PR TITLE
GIGA R1: fix for UDP endPacket failing 

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -60,6 +60,13 @@ int arduino::WiFiClass::begin(const char* ssid, const char* passphrase, wl_enc_t
     _security = ap_list[connected_ap].get_security();
   } else {
     // For hidden networks, the security mode must be set explicitly.
+    // if ENC_TYPE_UNKNOWN this means that is the default value and so the user
+    // has not set it... no worth trying, it is probably an unknown (not hidden) 
+    // interface
+    if(security == ENC_TYPE_UNKNOWN) {
+      _currentNetworkStatus = WL_CONNECT_FAILED;
+      return _currentNetworkStatus;
+    }
     _security = enum2sec(security);
   }
 

--- a/libraries/WiFi/src/WiFi.h
+++ b/libraries/WiFi/src/WiFi.h
@@ -74,7 +74,7 @@ public:
      * param passphrase: Passphrase. Valid characters in a passphrase
      *        must be between ASCII 32-126 (decimal).
      */
-  int begin(const char* ssid, const char* passphrase, wl_enc_type security = ENC_TYPE_CCMP);
+  int begin(const char* ssid, const char* passphrase, wl_enc_type security = ENC_TYPE_UNKNOWN);
 	
   // Inherit config methods from the parent class
   using MbedSocketClass::config;


### PR DESCRIPTION
Fix for #944 (GIGA R1, WiFiUDP::endPacket() fails after release 4.1.3)
Apparently the problem was introduced in 79d35efeeb94ee89c01e1dc934516cbfb26a3ef7 (this introduced support for hidden WiFi Network).
The "unknown" network mentioned in #944 was mistaken for an hidden network causing the problem (as a side effect the failed connection took much more time because of the re-tries to connect to not existent network).
The PR bypass the problem defaulting the security parameter of begin() to Unknown.
If the network is not hidden the security is taken from the connection itself.
If the network is hidden the user must set the security => if the security is Unknown the user has not set the security parameter, so this is an attempt to connect to a not existent network and the PR restore the previous behavior (no attempt to connect, this also remove the additional time).