### PR TITLE
Serial: remove intermediate_buffer leftover

### DIFF
--- a/cores/arduino/Serial.h
+++ b/cores/arduino/Serial.h
@@ -76,7 +76,6 @@ class UART : public HardwareSerial {
 		mbed_usb_serial* _usb_serial = NULL;
 		PinName _tx, _rx, _rts, _cts;
 		RingBufferN<256> rx_buffer;
-		uint8_t intermediate_buf[4];
 		bool is_usb = false;
 };
 }


### PR DESCRIPTION
The buffer is not used since this commit https://github.com/arduino/ArduinoCore-mbed/commit/bb77ad59ffcbd1fb562f5b7942210e348a248c44