### PR TITLE
Fix and simplify sni setting

### DIFF
--- a/libraries/SocketWrapper/src/AClient.cpp
+++ b/libraries/SocketWrapper/src/AClient.cpp
@@ -46,11 +46,11 @@ int arduino::AClient::connectSSL(IPAddress ip, uint16_t port) {
   return client->connectSSL(ip, port);
 }
 
-int arduino::AClient::connectSSL(const char *host, uint16_t port, bool disableSNI) {
+int arduino::AClient::connectSSL(const char *host, uint16_t port) {
   if (!client) {
     newMbedClient();
   }
-  return client->connectSSL(host, port, disableSNI);
+  return client->connectSSL(host, port);
 }
 
 void arduino::AClient::stop() {

--- a/libraries/SocketWrapper/src/AClient.h
+++ b/libraries/SocketWrapper/src/AClient.h
@@ -32,7 +32,7 @@ public:
   virtual int connect(IPAddress ip, uint16_t port);
   virtual int connect(const char *host, uint16_t port);
   int connectSSL(IPAddress ip, uint16_t port);
-  int connectSSL(const char* host, uint16_t port, bool disableSNI = false);
+  int connectSSL(const char* host, uint16_t port);
   virtual void stop();
 
   virtual explicit operator bool();

--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -186,15 +186,7 @@ int arduino::MbedClient::connectSSL(IPAddress ip, uint16_t port) {
   return connectSSL(SocketHelpers::socketAddressFromIpAddress(ip, port));
 }
 
-int arduino::MbedClient::connectSSL(const char *host, uint16_t port, bool disableSNI) {
-  if (!disableSNI) {
-    if (sock == nullptr) {
-      sock = new TLSSocket();
-      _own_socket = true;
-    }
-    static_cast<TLSSocket *>(sock)->set_hostname(host);
-  }
-
+int arduino::MbedClient::connectSSL(const char *host, uint16_t port) {
   SocketAddress socketAddress = SocketAddress();
   socketAddress.set_port(port);
   SocketHelpers::gethostbyname(getNetwork(), host, &socketAddress);

--- a/libraries/SocketWrapper/src/MbedClient.h
+++ b/libraries/SocketWrapper/src/MbedClient.h
@@ -56,7 +56,7 @@ public:
   virtual int connect(const char* host, uint16_t port);
   int connectSSL(SocketAddress socketAddress);
   int connectSSL(IPAddress ip, uint16_t port);
-  int connectSSL(const char* host, uint16_t port, bool disableSNI = false);
+  int connectSSL(const char* host, uint16_t port);
   size_t write(uint8_t);
   size_t write(const uint8_t* buf, size_t size);
   int available();

--- a/libraries/SocketWrapper/src/MbedSSLClient.h
+++ b/libraries/SocketWrapper/src/MbedSSLClient.h
@@ -41,7 +41,8 @@ public:
     return connectSSL(ip, port);
   }
   int connect(const char* host, uint16_t port) {
-    return connectSSL(host, port, _disableSNI);
+    _hostname = host;
+    return connectSSL(host, port);
   }
   void disableSNI(bool statusSNI) {
     _disableSNI = statusSNI;
@@ -53,6 +54,7 @@ public:
 
 protected:
   const char* _ca_cert_custom = NULL;
+  const char* _hostname = NULL;
 
 private:
   int setRootCA() {
@@ -78,6 +80,10 @@ private:
       return err;
     }
 #endif
+
+    if(_hostname && !_disableSNI) {
+      ((TLSSocket*)sock)->set_hostname(_hostname);
+    }
 
     if(_ca_cert_custom != NULL) {
       err = ((TLSSocket*)sock)->append_root_ca_cert(_ca_cert_custom);


### PR DESCRIPTION
https://github.com/arduino/ArduinoCore-mbed/pull/949 breaks `sni` setting. This PR restores sni functionality moving all `sni` code to the `SSLClient`

`sni` is enabled by default to disable it `disableSNI(true)` should be called explicitly.