### PR TITLE
Reduce nsapi dns response timeout:  5 seconds 3 retires

### DIFF
--- a/variants/GIGA/conf/mbed_app.json
+++ b/variants/GIGA/conf/mbed_app.json
@@ -11,6 +11,8 @@
       "rtos.main-thread-stack-size": 32768,
       "cordio.max-connections": 5,
       "target.mbed_app_start": "0x8040000",
+      "nsapi.dns-response-wait-time": 5000,
+      "nsapi.dns-total-attempts": 3,
       "target.macros_add": [
         "METAL_INTERNAL",
         "VIRTIO_DRIVER_ONLY",

--- a/variants/NICLA_VISION/conf/mbed_app.json
+++ b/variants/NICLA_VISION/conf/mbed_app.json
@@ -12,6 +12,8 @@
       "rtos.main-thread-stack-size": 32768,
       "cordio.max-connections": 5,
       "target.mbed_app_start": "0x8040000",
+      "nsapi.dns-response-wait-time": 5000,
+      "nsapi.dns-total-attempts": 3,
       "target.macros_add": [
         "METAL_INTERNAL",
         "VIRTIO_DRIVER_ONLY",

--- a/variants/OPTA/conf/mbed_app.json
+++ b/variants/OPTA/conf/mbed_app.json
@@ -11,6 +11,8 @@
       "rtos.main-thread-stack-size": 32768,
       "cordio.max-connections": 5,
       "target.mbed_app_start": "0x8040000",
+      "nsapi.dns-response-wait-time": 5000,
+      "nsapi.dns-total-attempts": 3,
       "target.macros_add": [
         "METAL_INTERNAL",
         "VIRTIO_DRIVER_ONLY",

--- a/variants/PORTENTA_H7_M7/conf/mbed_app.json
+++ b/variants/PORTENTA_H7_M7/conf/mbed_app.json
@@ -15,6 +15,8 @@
       "cellular.at-handler-buffer-size": 512,
       "mbed-trace.enable": true,
       "target.mbed_app_start": "0x8040000",
+      "nsapi.dns-response-wait-time": 5000,
+      "nsapi.dns-total-attempts": 3,
       "target.macros_add": [
         "BT_UART_NO_3M_SUPPORT",
         "USB_DYNAMIC_CONFIGURATION",


### PR DESCRIPTION
Currently the nsapi is configured with a default value of 10s of timeout and with 10 attempts before failure.
In case internet is not available (but the board is correctly connected to the AP), with this set of parameters the sketch is waiting for 100 s stopping the main loop. If you are using an ArduinoIoTCloud sketch the board is rebooted by the watchdog timer
