### PR TITLE
Make uniform the returned WiFi FW Version value

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -385,9 +385,13 @@ const char* arduino::WiFiClass::firmwareVersion() {
   }
 
   if (firmware_available) {
-    return WHD_VERSION;
+    const char* whd_version = WHD_VERSION;
+    if (whd_version[0] == 'v') {
+      return  ++whd_version;
+    }
+    return whd_version;
   } else {
-    return "v0.0.0";
+    return "0.0.0";
   }
 }
 


### PR DESCRIPTION
Uniform the returned WiFi FW Version value with other board cores removing the first character `'v'`