### PR TITLE
Get the status of the display.

### DIFF
--- a/libraries/Arduino_H7_Video/src/Arduino_H7_Video.cpp
+++ b/libraries/Arduino_H7_Video/src/Arduino_H7_Video.cpp
@@ -179,6 +179,11 @@ bool Arduino_H7_Video::isRotated() {
   return _rotated;
 }
 
+int Arduino_H7_Video::getStatus()
+{
+  return _shield->getStatus();
+}
+
 void Arduino_H7_Video::end() {
 #ifdef HAS_ARDUINOGRAPHICS
   ArduinoGraphics::end();

--- a/libraries/Arduino_H7_Video/src/Arduino_H7_Video.h
+++ b/libraries/Arduino_H7_Video/src/Arduino_H7_Video.h
@@ -106,6 +106,13 @@ public:
    */
   bool isRotated();
 
+  /**
+   * @brief Get the status of the display.
+   * 
+   * @return int The Status of the display.
+   */
+   int getStatus();
+
 #ifdef HAS_ARDUINOGRAPHICS
   /**
    * @brief Clear the display.

--- a/libraries/Arduino_H7_Video/src/H7DisplayShield.cpp
+++ b/libraries/Arduino_H7_Video/src/H7DisplayShield.cpp
@@ -18,6 +18,10 @@ int GigaDisplayShieldClass::getEdidMode(int h, int v) {
     return EDID_MODE_480x800_60Hz;
 }
 
+int GigaDisplayShieldClass::getStatus() {
+    return 1;
+}
+
 int USBCVideoClass::init(int edidmode) {
     struct edid recognized_edid;
     int err_code = 0;
@@ -55,6 +59,12 @@ int USBCVideoClass::getEdidMode(int h, int v) {
     int edidmode = video_modes_get_edid(h, v);
 
     return edidmode;
+}
+
+int USBCVideoClass::getStatus() {
+    int detected = anx7625_get_hpd_event(0);
+
+    return detected;
 }
 
 GigaDisplayShieldClass GigaDisplayShield;

--- a/libraries/Arduino_H7_Video/src/H7DisplayShield.h
+++ b/libraries/Arduino_H7_Video/src/H7DisplayShield.h
@@ -5,18 +5,21 @@ class H7DisplayShield {
     public:
         virtual int init(int edidmode) = 0;
         virtual int getEdidMode(int h, int v);
+        virtual int getStatus();
 };
 
 class GigaDisplayShieldClass : public H7DisplayShield {
     public:
         int init(int edidmode);
         int getEdidMode(int h, int v);
+        int getStatus();
 };
 
 class USBCVideoClass : public H7DisplayShield {
     public:
         int init(int edidmode);
         int getEdidMode(int h, int v);
+        int getStatus();
 };
 
 extern GigaDisplayShieldClass GigaDisplayShield;

--- a/libraries/Arduino_H7_Video/src/anx7625.cpp
+++ b/libraries/Arduino_H7_Video/src/anx7625.cpp
@@ -630,6 +630,11 @@ bool anx7625_is_power_provider(uint8_t bus) {
 	}
 }
 
+int anx7625_get_hpd_event(uint8_t bus)  {
+	int ret = anx7625_hpd_change_detect(bus);;
+	return ret;
+}
+
 int i2c_writeb(uint8_t bus, uint8_t saddr, uint8_t offset, uint8_t val) {
 	char cmd[2];
 	cmd[0] = offset;

--- a/libraries/Arduino_H7_Video/src/anx7625.h
+++ b/libraries/Arduino_H7_Video/src/anx7625.h
@@ -24,5 +24,6 @@ int 	anx7625_wait_hpd_event(uint8_t bus);
 int 	anx7625_get_cc_status(uint8_t bus, uint8_t *cc_status);
 int 	anx7625_read_system_status(uint8_t bus, uint8_t *sys_status);
 bool 	anx7625_is_power_provider(uint8_t bus);
+int 	anx7625_get_hpd_event(uint8_t bus);
 
 #endif  /* _ANX7625_H */


### PR DESCRIPTION
This functionality expose getStatus method for obtain the shield status.

Example usage:

```c++
if (Display.getStatus() <= 0) {
  NVIC_SystemReset();
}
```

in the production environment we have noticed the loss of connection to the display on the portenta h7 and this modification identifies this problem and allows an action to resolve the problem.
