### PR TITLE
Ping: Expose timeout to interfaces

### DIFF
--- a/libraries/SocketWrapper/src/SocketHelpers.cpp
+++ b/libraries/SocketWrapper/src/SocketHelpers.cpp
@@ -75,22 +75,22 @@ arduino::IPAddress arduino::MbedSocketClass::dnsIP(int n) {
   return ipAddressFromSocketAddress(ip);
 }
 
-int arduino::MbedSocketClass::ping(const char *hostname, uint8_t ttl)
+int arduino::MbedSocketClass::ping(const char *hostname, uint8_t ttl, uint32_t timeout)
 {
   SocketAddress socketAddress;
   gethostbyname(getNetwork(),hostname, &socketAddress);
-  return ping(socketAddress, ttl);
+  return ping(socketAddress, ttl, timeout);
 }
 
-int arduino::MbedSocketClass::ping(const String &hostname, uint8_t ttl)
+int arduino::MbedSocketClass::ping(const String &hostname, uint8_t ttl, uint32_t timeout)
 {
-  return ping(hostname.c_str(), ttl);
+  return ping(hostname.c_str(), ttl, timeout);
 }
 
-int arduino::MbedSocketClass::ping(IPAddress host, uint8_t ttl)
+int arduino::MbedSocketClass::ping(IPAddress host, uint8_t ttl, uint32_t timeout)
 {
   SocketAddress socketAddress = socketAddressFromIpAddress(host, 0);
-  return ping(socketAddress, ttl);
+  return ping(socketAddress, ttl, timeout);
 }
 
 void arduino::MbedSocketClass::config(arduino::IPAddress local_ip) {

--- a/libraries/SocketWrapper/src/SocketHelpers.h
+++ b/libraries/SocketWrapper/src/SocketHelpers.h
@@ -118,9 +118,9 @@ public:
    *
    * return: RTT in milliseconds or -1 on error
    */
-  int ping(const char* hostname, uint8_t ttl = 255);
-  int ping(const String &hostname, uint8_t ttl = 255);
-  int ping(IPAddress host, uint8_t ttl = 255);
+  int ping(const char* hostname, uint8_t ttl = 255, uint32_t timeout = 5000);
+  int ping(const String &hostname, uint8_t ttl = 255, uint32_t timeout = 5000);
+  int ping(IPAddress host, uint8_t ttl = 255, uint32_t timeout = 5000);
 
   /*
    * Download a file from an HTTP endpoint and save it in the provided `target` location on the fs
@@ -185,7 +185,7 @@ protected:
 
   void body_callback(const char* data, uint32_t data_len);
 
-  int ping(SocketAddress &socketAddress, uint8_t ttl, uint32_t timeout = 5000);
+  int ping(SocketAddress &socketAddress, uint8_t ttl, uint32_t timeout);
   static arduino::IPAddress ipAddressFromSocketAddress(SocketAddress socketAddress);
   static SocketAddress socketAddressFromIpAddress(arduino::IPAddress ip, uint16_t port);
   static nsapi_error_t gethostbyname(NetworkInterface* interface, const char* aHostname, SocketAddress* socketAddress);


### PR DESCRIPTION
To allow default ping ICMP socket timeout override. Fixes #1035 