### PR TITLE
Update MbedClient.cpp fix readSocket osPriority and name the thread

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -71,7 +71,7 @@ void arduino::MbedClient::configureSocket(Socket *_s) {
   }
   mutex->lock();
   if (reader_th == nullptr) {
-    reader_th = new rtos::Thread(osPriorityNormal - 2);
+    reader_th = new rtos::Thread(osPriorityNormal, OS_STACK_SIZE, nullptr, "readSocket");
     reader_th->start(mbed::callback(this, &MbedClient::readSocket));
   }
   mutex->unlock();


### PR DESCRIPTION
osPriority as coded is invalid but ignored. This PR corrects the priority and names the thread. fixes #996 