### PR TITLE
Update WiFi.cpp to set connected_ap = SSID_MAX_COUNT if not scanning

### DIFF
--- a/libraries/WiFi/src/WiFi.cpp
+++ b/libraries/WiFi/src/WiFi.cpp
@@ -67,6 +67,7 @@ int arduino::WiFiClass::begin(const char* ssid, const char* passphrase, wl_enc_t
       return _currentNetworkStatus;
     }
   } else {
+    connected_ap = SSID_MAX_COUNT;
     _security = enum2sec(security);
   }
 


### PR DESCRIPTION
Currently arduino::WiFiClass::encryptionType() is using an uninitialised connected_ap variable if network scanning has been skipped due to the enc type being specified in the WiFi.begin() call. encryptionType() is typically returning ENC_TYPE_AUTO instead of the enc type used in the begin() call.